### PR TITLE
Fixes for reset password

### DIFF
--- a/packages/server/src/accounts-server.ts
+++ b/packages/server/src/accounts-server.ts
@@ -697,7 +697,8 @@ export class AccountsServer {
 
     // TODO move this getter into a password service module
     const resetTokens = get(user, ['services', 'password', 'reset']) || [];
-    const resetTokenRecord = (isArray(resetTokens) ? resetTokens : [resetTokens]).find(resetTokens, t => t.token === token);
+    const asArray = isArray(resetTokens) ? resetTokens : [resetTokens];
+    const resetTokenRecord = find(asArray, t => t.token === token);
 
     if (this._isTokenExpired(token, resetTokenRecord)) {
       throw new AccountsError('Reset password link expired');

--- a/packages/server/src/accounts-server.ts
+++ b/packages/server/src/accounts-server.ts
@@ -696,7 +696,7 @@ export class AccountsServer {
     }
 
     // TODO move this getter into a password service module
-    const resetTokens = get(user, ['services', 'password', 'reset']) || [];
+    const resetTokens = get(user, ['services', 'password', 'reset'], []);
     const asArray = isArray(resetTokens) ? resetTokens : [resetTokens];
     const resetTokenRecord = find(asArray, t => t.token === token);
 

--- a/packages/server/src/accounts-server.ts
+++ b/packages/server/src/accounts-server.ts
@@ -5,6 +5,7 @@ import * as omit from 'lodash/omit';
 import * as isString from 'lodash/isString';
 import * as isPlainObject from 'lodash/isPlainObject';
 import * as isFunction from 'lodash/isFunction';
+import * as isArray from 'lodash/isArray';
 import * as find from 'lodash/find';
 import * as includes from 'lodash/includes';
 import * as get from 'lodash/get';
@@ -695,8 +696,8 @@ export class AccountsServer {
     }
 
     // TODO move this getter into a password service module
-    const resetTokens = get(user, ['services', 'password', 'reset']);
-    const resetTokenRecord = find(resetTokens, t => t.token === token);
+    const resetTokens = get(user, ['services', 'password', 'reset']) || [];
+    const resetTokenRecord = (isArray(resetTokens) ? resetTokens : [resetTokens]).find(resetTokens, t => t.token === token);
 
     if (this._isTokenExpired(token, resetTokenRecord)) {
       throw new AccountsError('Reset password link expired');

--- a/packages/server/src/accounts-server.ts
+++ b/packages/server/src/accounts-server.ts
@@ -705,10 +705,12 @@ export class AccountsServer {
     }
 
     const emails = user.emails || [];
+    const tokenAddress = resetTokenRecord.email || resetTokenRecord.address;
+
     if (
       !includes(
         emails.map((email: EmailRecord) => email.address),
-        resetTokenRecord.address
+        tokenAddress
       )
     ) {
       throw new AccountsError('Token has invalid email address');


### PR DESCRIPTION
In some version of Meteor, the `services.password.reset` in an object, and in some an Array.
Also, in some versions the reset password token has an `address` field, and in some it's `email`. 

This PR includes fixes for both issues