### PR TITLE
Fix missing import on email server

### DIFF
--- a/packages/server/src/accounts-server.ts
+++ b/packages/server/src/accounts-server.ts
@@ -412,7 +412,7 @@ export class AccountsServer {
       let sessionId;
       try {
         jwt.verify(refreshToken, this._options.tokenSecret);
-        const decodedAccessToken = jwt.verify(
+        const decodedAccessToken: any = jwt.verify(
           accessToken,
           this._options.tokenSecret,
           {
@@ -574,7 +574,7 @@ export class AccountsServer {
 
     let sessionId;
     try {
-      const decodedAccessToken = jwt.verify(
+      const decodedAccessToken: any = jwt.verify(
         accessToken,
         this._options.tokenSecret
       );

--- a/packages/server/src/email.ts
+++ b/packages/server/src/email.ts
@@ -1,4 +1,4 @@
-import email, { Client } from 'emailjs';
+import { Client, server as emailServer } from 'emailjs';
 
 export interface EmailConnector {
   sendMail(mail: object): Promise<object>;
@@ -9,7 +9,7 @@ class Email {
 
   constructor(emailConfig: object) {
     if (emailConfig) {
-      this.server = email.server.connect(emailConfig);
+      this.server = emailServer.connect(emailConfig);
     }
   }
 


### PR DESCRIPTION
TS does not auto import * when there is no default import. emailjs does not specify default import so it was broken since moving to TS.