### PR TITLE
use random tokens instead of sessionId inside sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@ lib/
 node_modules/
 coverage/
 npm-debug.log
-.idea
 lerna-debug.log
+yarn-error.log
+.idea
 .vscode
 packages/*/package-lock.json

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -49,7 +49,7 @@ export interface ImpersonateReturnType {
 }
 
 export interface SessionType {
-  sessionId: string;
+  id: string;
   userId: string;
   token: string;
   valid: boolean;

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -51,6 +51,7 @@ export interface ImpersonateReturnType {
 export interface SessionType {
   sessionId: string;
   userId: string;
+  token: string;
   valid: boolean;
   userAgent?: string;
   createdAt: string;

--- a/packages/server/__tests__/accounts-server.ts
+++ b/packages/server/__tests__/accounts-server.ts
@@ -115,7 +115,7 @@ describe('AccountsServer', () => {
           db: {
             findSessionByToken: () =>
               Promise.resolve({
-                sessionId: '456',
+                id: '456',
                 valid: true,
                 userId: '123',
               }),
@@ -147,7 +147,7 @@ describe('AccountsServer', () => {
           db: {
             findSessionByToken: () =>
               Promise.resolve({
-                sessionId: '456',
+                id: '456',
                 valid: true,
                 userId: '123',
               }),
@@ -219,7 +219,7 @@ describe('AccountsServer', () => {
           db: {
             findSessionByToken: () =>
               Promise.resolve({
-                sessionId: '456',
+                id: '456',
                 valid: true,
                 userId: '123',
               }),
@@ -244,7 +244,7 @@ describe('AccountsServer', () => {
           db: {
             findSessionByToken: () =>
               Promise.resolve({
-                sessionId: '456',
+                id: '456',
                 valid: true,
                 userId: '123',
               }),
@@ -277,7 +277,7 @@ describe('AccountsServer', () => {
           db: {
             findSessionByToken: () =>
               Promise.resolve({
-                sessionId: '456',
+                id: '456',
                 valid: true,
                 userId: '123',
               }),
@@ -307,7 +307,7 @@ describe('AccountsServer', () => {
           db: {
             findSessionByToken: () =>
               Promise.resolve({
-                sessionId: '456',
+                id: '456',
                 valid: false,
                 userId: '123',
               }),
@@ -403,7 +403,7 @@ describe('AccountsServer', () => {
           db: {
             findSessionByToken: () =>
               Promise.resolve({
-                sessionId: '456',
+                id: '456',
                 valid: true,
                 userId: '123',
               }),
@@ -505,7 +505,7 @@ describe('AccountsServer', () => {
           db: {
             findSessionByToken: () =>
               Promise.resolve({
-                sessionId: '456',
+                id: '456',
                 valid: true,
                 userId: '123',
               }),
@@ -632,7 +632,7 @@ describe('AccountsServer', () => {
           db: {
             findSessionByToken: () =>
               Promise.resolve({
-                sessionId: '456',
+                id: '456',
                 valid: true,
                 userId: '123',
               }),
@@ -752,7 +752,7 @@ describe('AccountsServer', () => {
           db: {
             findSessionByToken: () =>
               Promise.resolve({
-                sessionId: '456',
+                id: '456',
                 valid: true,
                 userId: '123',
               }),
@@ -783,7 +783,7 @@ describe('AccountsServer', () => {
           db: {
             findSessionByToken: () =>
               Promise.resolve({
-                sessionId: '456',
+                id: '456',
                 valid: false,
                 userId: '123',
               }),
@@ -808,7 +808,7 @@ describe('AccountsServer', () => {
           db: {
             findSessionByToken: () =>
               Promise.resolve({
-                sessionId: '456',
+                id: '456',
                 valid: true,
                 userId: '123',
               }),

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -27,8 +27,7 @@
     "moduleFileExtensions": [
       "ts",
       "js"
-    ],
-    "mapCoverage": true
+    ]
   },
   "repository": {
     "type": "git",

--- a/packages/server/src/accounts-server.ts
+++ b/packages/server/src/accounts-server.ts
@@ -28,6 +28,11 @@ export interface TokenRecord {
   reason: string;
 }
 
+export interface JwtData {
+  token: string;
+  isImpersonated: boolean;
+}
+
 const defaultOptions = {
   tokenSecret: 'secret',
   tokenConfigs: {
@@ -181,7 +186,12 @@ export class AccountsServer {
     const { ip, userAgent } = infos;
 
     try {
-      const sessionId = await this.db.createSession(user.id, ip, userAgent);
+      // TODO get a random token
+      const token = '';
+      const sessionId = await this.db.createSession(user.id, token, {
+        ip,
+        userAgent,
+      });
       const { accessToken, refreshToken } = this.createTokens(sessionId);
 
       const loginResult = {
@@ -256,10 +266,15 @@ export class AccountsServer {
         return { authorized: false };
       }
 
+      // TODO get a random token
+      const token = '';
       const newSessionId = await this.db.createSession(
         impersonatedUser.id,
-        ip,
-        userAgent,
+        token,
+        {
+          ip,
+          userAgent,
+        },
         { impersonatorUserId: user.id }
       );
       const impersonationTokens = this.createTokens(newSessionId, true);
@@ -302,22 +317,24 @@ export class AccountsServer {
         throw new AccountsError('An accessToken and refreshToken are required');
       }
 
-      let sessionId;
+      let sessionToken: string;
       try {
         jwt.verify(refreshToken, this.options.tokenSecret);
-        const decodedAccessToken: any = jwt.verify(
+        const decodedAccessToken = jwt.verify(
           accessToken,
           this.options.tokenSecret,
           {
             ignoreExpiration: true,
           }
-        );
-        sessionId = decodedAccessToken.data.sessionId;
+        ) as { data: JwtData };
+        sessionToken = decodedAccessToken.data.token;
       } catch (err) {
         throw new AccountsError('Tokens are not valid');
       }
 
-      const session: SessionType = await this.db.findSessionById(sessionId);
+      const session: SessionType = await this.db.findSessionByToken(
+        sessionToken
+      );
       if (!session) {
         throw new AccountsError('Session not found');
       }
@@ -327,11 +344,11 @@ export class AccountsServer {
         if (!user) {
           throw new AccountsError('User not found', { id: session.userId });
         }
-        const tokens = this.createTokens(sessionId);
-        await this.db.updateSession(sessionId, ip, userAgent);
+        const tokens = this.createTokens(sessionToken);
+        await this.db.updateSession(sessionToken, { ip, userAgent });
 
         const result = {
-          sessionId,
+          sessionId: session.sessionId,
           user: this.sanitizeUser(user),
           tokens,
         };
@@ -353,20 +370,21 @@ export class AccountsServer {
 
   /**
    * @description Refresh a user token.
-   * @param {string} sessionId - User session id.
+   * @param {string} token - User session token.
    * @param {boolean} isImpersonated - Should be true if impersonating another user.
    * @returns {Promise<Object>} - Return a new accessToken and refreshToken.
    */
   public createTokens(
-    sessionId: string,
+    token: string,
     isImpersonated: boolean = false
   ): TokensType {
     const { tokenSecret, tokenConfigs } = this.options;
+    const jwtData: JwtData = {
+      token,
+      isImpersonated,
+    };
     const accessToken = generateAccessToken({
-      data: {
-        sessionId,
-        isImpersonated,
-      },
+      data: jwtData,
       secret: tokenSecret,
       config: tokenConfigs.accessToken || {},
     });
@@ -453,6 +471,11 @@ export class AccountsServer {
     }
   }
 
+  /**
+   * @description Find a session by his token.
+   * @param {string} accessToken
+   * @returns {Promise<SessionType>} - Return a session.
+   */
   public async findSessionByAccessToken(
     accessToken: string
   ): Promise<SessionType> {
@@ -460,18 +483,18 @@ export class AccountsServer {
       throw new AccountsError('An accessToken is required');
     }
 
-    let sessionId;
+    let sessionToken: string;
     try {
-      const decodedAccessToken: any = jwt.verify(
+      const decodedAccessToken = jwt.verify(
         accessToken,
         this.options.tokenSecret
-      );
-      sessionId = decodedAccessToken.data.sessionId;
+      ) as { data: JwtData };
+      sessionToken = decodedAccessToken.data.token;
     } catch (err) {
       throw new AccountsError('Tokens are not valid');
     }
 
-    const session: SessionType = await this.db.findSessionById(sessionId);
+    const session: SessionType = await this.db.findSessionByToken(sessionToken);
     if (!session) {
       throw new AccountsError('Session not found');
     }

--- a/packages/server/src/accounts-server.ts
+++ b/packages/server/src/accounts-server.ts
@@ -12,7 +12,11 @@ import {
   ImpersonateReturnType,
   HookListener,
 } from '@accounts/common';
-import { generateAccessToken, generateRefreshToken, generateRandomToken } from './tokens';
+import {
+  generateAccessToken,
+  generateRefreshToken,
+  generateRandomToken,
+} from './tokens';
 import { emailTemplates, EmailTemplateType, sendMail } from './email';
 import {
   AccountsServerOptions,

--- a/packages/server/src/accounts-server.ts
+++ b/packages/server/src/accounts-server.ts
@@ -12,7 +12,7 @@ import {
   ImpersonateReturnType,
   HookListener,
 } from '@accounts/common';
-import { generateAccessToken, generateRefreshToken } from './tokens';
+import { generateAccessToken, generateRefreshToken, generateRandomToken } from './tokens';
 import { emailTemplates, EmailTemplateType, sendMail } from './email';
 import {
   AccountsServerOptions,
@@ -186,13 +186,12 @@ export class AccountsServer {
     const { ip, userAgent } = infos;
 
     try {
-      // TODO get a random token
-      const token = '';
+      const token = generateRandomToken();
       const sessionId = await this.db.createSession(user.id, token, {
         ip,
         userAgent,
       });
-      const { accessToken, refreshToken } = this.createTokens(sessionId);
+      const { accessToken, refreshToken } = this.createTokens(token);
 
       const loginResult = {
         sessionId,
@@ -266,8 +265,7 @@ export class AccountsServer {
         return { authorized: false };
       }
 
-      // TODO get a random token
-      const token = '';
+      const token = generateRandomToken();
       const newSessionId = await this.db.createSession(
         impersonatedUser.id,
         token,

--- a/packages/server/src/accounts-server.ts
+++ b/packages/server/src/accounts-server.ts
@@ -347,10 +347,10 @@ export class AccountsServer {
           throw new AccountsError('User not found', { id: session.userId });
         }
         const tokens = this.createTokens(sessionToken);
-        await this.db.updateSession(session.sessionId, { ip, userAgent });
+        await this.db.updateSession(session.id, { ip, userAgent });
 
         const result = {
-          sessionId: session.sessionId,
+          sessionId: session.id,
           user: this.sanitizeUser(user),
           tokens,
         };
@@ -415,7 +415,7 @@ export class AccountsServer {
           throw new AccountsError('User not found', { id: session.userId });
         }
 
-        await this.db.invalidateSession(session.sessionId);
+        await this.db.invalidateSession(session.id);
         this.hooks.emit(
           ServerHooks.LogoutSuccess,
           this.sanitizeUser(user),

--- a/packages/server/src/accounts-server.ts
+++ b/packages/server/src/accounts-server.ts
@@ -347,7 +347,7 @@ export class AccountsServer {
           throw new AccountsError('User not found', { id: session.userId });
         }
         const tokens = this.createTokens(sessionToken);
-        await this.db.updateSession(sessionToken, { ip, userAgent });
+        await this.db.updateSession(session.sessionId, { ip, userAgent });
 
         const result = {
           sessionId: session.sessionId,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,7 +1,7 @@
 import { AccountsServer } from './accounts-server';
 import * as encryption from './encryption';
 import { generateRandomToken } from './tokens';
-import { AuthService, DBInterface } from './types';
+import { AuthService, DBInterface, ConnectionInformationsType } from './types';
 
 export default AccountsServer;
 export {
@@ -10,4 +10,5 @@ export {
   encryption,
   DBInterface,
   generateRandomToken,
+  ConnectionInformationsType,
 };

--- a/packages/server/src/tokens.ts
+++ b/packages/server/src/tokens.ts
@@ -1,7 +1,10 @@
 import * as jwt from 'jsonwebtoken';
 import { randomBytes } from 'crypto';
 
-export const generateRandomToken = (length: number = 43) =>
+/**
+ * Generate a random token string
+ */
+export const generateRandomToken = (length: number = 43): string =>
   randomBytes(length).toString('hex');
 
 export const generateAccessToken = ({

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -123,6 +123,6 @@ export interface DBInterface {
     token: string,
     connection: ConnectionInformationsType
   ): Promise<void>;
-  invalidateSession(token: string): Promise<void>;
+  invalidateSession(sessionId: string): Promise<void>;
   invalidateAllSessions(userId: string): Promise<void>;
 }

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -111,6 +111,7 @@ export interface DBInterface {
   ): Promise<void>;
 
   // Session related operations
+  findSessionById(sessionId: string): Promise<SessionType | null>;
   findSessionByToken(token: string): Promise<SessionType | null>;
   createSession(
     userId: string,

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -111,18 +111,17 @@ export interface DBInterface {
   ): Promise<void>;
 
   // Session related operations
-  findSessionById(sessionId: string): Promise<SessionType | null>;
+  findSessionByToken(token: string): Promise<SessionType | null>;
   createSession(
     userId: string,
-    ip?: string,
-    userAgent?: string,
+    token: string,
+    connection: ConnectionInformationsType,
     extraData?: object
   ): Promise<string>;
   updateSession(
-    sessionId: string,
-    ip?: string,
-    userAgent?: string
+    token: string,
+    connection: ConnectionInformationsType
   ): Promise<void>;
-  invalidateSession(sessionId: string): Promise<void>;
+  invalidateSession(token: string): Promise<void>;
   invalidateAllSessions(userId: string): Promise<void>;
 }

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -120,7 +120,7 @@ export interface DBInterface {
     extraData?: object
   ): Promise<string>;
   updateSession(
-    token: string,
+    sessionId: string,
     connection: ConnectionInformationsType
   ): Promise<void>;
   invalidateSession(sessionId: string): Promise<void>;


### PR DESCRIPTION
The goal of the pr is to change the information stored in the jwt. We are currently storing the sessionId which can be predictable, so if someone succeed to get your jwt secret, he will be able to impersonate any user you have and you will not notice it.
If we switch the session id with a random token which is not predictable we remove this potential security issue.