### PR TITLE
@accounts/error : new AccountsError package with message formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@accounts/tslint-config-accounts": "0.0.6",
+    "@accounts/tslint-config-accounts": "0.0.9",
     "@types/jest": "22.2.0",
     "@types/node": "9.4.6",
     "codecov": "3.0.0",

--- a/packages/error/.npmignore
+++ b/packages/error/.npmignore
@@ -1,0 +1,7 @@
+__tests__
+src/
+coverage/
+node_modules
+tsconfig.json
+.npmignore
+yarn.lock

--- a/packages/error/__tests__/accounts-error.ts
+++ b/packages/error/__tests__/accounts-error.ts
@@ -1,0 +1,32 @@
+import AccountsError from '../src'
+
+describe('AccountsError', () => {
+  it('should return an Error', () => {
+    expect(new AccountsError() instanceof Error).toBe(true);
+  });
+
+  it('should be an instance of AccountsError', () => {
+    expect(new AccountsError() instanceof AccountsError).toBe(true);
+  });
+
+  it('should take 1 parameter and make it it\'s message', () => {
+    expect(new AccountsError('message').message).toBe('message');
+  });
+
+  it('should take 3 parameter and make a formatted Message', () => {
+    expect(new AccountsError('Package', 'method', 'reason').message).toBe('[ Accounts - Package ] method : reason');
+  });
+
+  it('should have a public property packageName', () => {
+    expect(new AccountsError('Package', 'method', 'reason').packageName).toBe('Package');
+  });
+
+  it('should have a public property functionName', () => {
+    expect(new AccountsError('Package', 'method', 'reason').functionName).toBe('method');
+  });
+
+  it('should have a public property reason', () => {
+    expect(new AccountsError('Package', 'method', 'reason').reason).toBe('reason');
+  });
+
+});

--- a/packages/error/__tests__/accounts-error.ts
+++ b/packages/error/__tests__/accounts-error.ts
@@ -1,4 +1,4 @@
-import AccountsError from '../src'
+import AccountsError from '../src';
 
 describe('AccountsError', () => {
   it('should return an Error', () => {
@@ -9,7 +9,7 @@ describe('AccountsError', () => {
     expect(new AccountsError() instanceof AccountsError).toBe(true);
   });
 
-  it('should take 1 parameter and make it it\'s message', () => {
+  it("should take 1 parameter and make it it's message", () => {
     expect(new AccountsError('message').message).toBe('message');
   });
 
@@ -34,5 +34,4 @@ describe('AccountsError', () => {
   it('should capture a stackTrace even if Error.captureStackTrace is not available', () => {
     expect(new AccountsError().stack).not.toBe(undefined);
   });
-
 });

--- a/packages/error/__tests__/accounts-error.ts
+++ b/packages/error/__tests__/accounts-error.ts
@@ -29,4 +29,10 @@ describe('AccountsError', () => {
     expect(new AccountsError('Package', 'method', 'reason').reason).toBe('reason');
   });
 
+  Error.captureStackTrace = null;
+
+  it('should capture a stackTrace even if Error.captureStackTrace is not available', () => {
+    expect(new AccountsError().stack).not.toBe(undefined);
+  });
+
 });

--- a/packages/error/__tests__/accounts-error.ts
+++ b/packages/error/__tests__/accounts-error.ts
@@ -1,7 +1,6 @@
 import AccountsError from '../src'
 
 describe('AccountsError', () => {
-
   it('should return an Error', () => {
     expect(new AccountsError() instanceof Error).toBe(true);
   });
@@ -30,28 +29,10 @@ describe('AccountsError', () => {
     expect(new AccountsError('Package', 'method', 'reason').reason).toBe('reason');
   });
 
-  it('should capture the stackTrace', () => {
-    Error.captureStackTrace = jest.fn(()=>null);
-    new AccountsError()
-    expect(Error.captureStackTrace).toHaveBeenCalled();
-  });
-
   Error.captureStackTrace = null;
 
   it('should capture a stackTrace even if Error.captureStackTrace is not available', () => {
     expect(new AccountsError().stack).not.toBe(undefined);
   });
-
-  /* it('should call super', ()=>{
-    const trigger = jest.fn(()=>null);
-    const eee = Error
-    Error.call = function(error, message){
-      trigger(message)
-      return eee(error, message)
-    }
-    const a = new AccountsError('test')
-    
-    expect(trigger).toHaveBeenCalledWith('test')
-  }) */
 
 });

--- a/packages/error/__tests__/accounts-error.ts
+++ b/packages/error/__tests__/accounts-error.ts
@@ -1,6 +1,7 @@
 import AccountsError from '../src'
 
 describe('AccountsError', () => {
+
   it('should return an Error', () => {
     expect(new AccountsError() instanceof Error).toBe(true);
   });
@@ -29,10 +30,28 @@ describe('AccountsError', () => {
     expect(new AccountsError('Package', 'method', 'reason').reason).toBe('reason');
   });
 
+  it('should capture the stackTrace', () => {
+    Error.captureStackTrace = jest.fn(()=>null);
+    new AccountsError()
+    expect(Error.captureStackTrace).toHaveBeenCalled();
+  });
+
   Error.captureStackTrace = null;
 
   it('should capture a stackTrace even if Error.captureStackTrace is not available', () => {
     expect(new AccountsError().stack).not.toBe(undefined);
   });
+
+  /* it('should call super', ()=>{
+    const trigger = jest.fn(()=>null);
+    const eee = Error
+    Error.call = function(error, message){
+      trigger(message)
+      return eee(error, message)
+    }
+    const a = new AccountsError('test')
+    
+    expect(trigger).toHaveBeenCalledWith('test')
+  }) */
 
 });

--- a/packages/error/__tests__/index.ts
+++ b/packages/error/__tests__/index.ts
@@ -1,4 +1,4 @@
-import AccountsError from '../src'
+import AccountsError from '../src';
 
 describe('AccountsError', () => {
   it('should have a default export AccountsError', () => {

--- a/packages/error/__tests__/index.ts
+++ b/packages/error/__tests__/index.ts
@@ -1,0 +1,7 @@
+import AccountsError from '../src'
+
+describe('AccountsError', () => {
+  it('should have a default export AccountsError', () => {
+    expect(typeof AccountsError).toBe('function');
+  });
+});

--- a/packages/error/package.json
+++ b/packages/error/package.json
@@ -31,7 +31,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/js-accounts/accounts/tree/master/packages/server"
+    "url": "https://github.com/accounts-js/accounts/tree/master/packages/error"
   },
   "keywords": [
     "rest",

--- a/packages/error/package.json
+++ b/packages/error/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@accounts/error",
+  "version": "0.1.0-beta.3",
+  "description": "Accounts-js Error",
+  "main": "lib/index.js",
+  "typings": "lib/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "clean": "rimraf lib",
+    "start": "tsc --watch",
+    "precompile": "yarn clean",
+    "compile": "tsc",
+    "prepublishOnly": "yarn compile",
+    "test": "yarn testonly",
+    "test-ci": "yarn lint && yarn coverage",
+    "testonly": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "yarn testonly -- --coverage"
+  },
+  "jest": {
+    "transform": {
+      ".(ts|tsx)": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
+    },
+    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx)$",
+    "moduleFileExtensions": [
+      "ts",
+      "js"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/js-accounts/accounts/tree/master/packages/server"
+  },
+  "keywords": [
+    "rest",
+    "graphql",
+    "grant",
+    "auth",
+    "authentication",
+    "accounts",
+    "users",
+    "oauth"
+  ],
+  "author": "Elies Lou (Aetherall)",
+  "license": "MIT",
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  }
+}

--- a/packages/error/src/accounts-error.ts
+++ b/packages/error/src/accounts-error.ts
@@ -1,0 +1,35 @@
+export default class AccountsError extends Error {
+
+  public packageName?: string;
+
+  public functionName?: string;
+
+  public reason?: string;
+
+  constructor(packageName?: string, functionName?: string, reason?: string){
+
+    // Build Error message from parameters
+    const message = reason 
+    ? `[ Accounts - ${packageName} ] ${functionName} : ${reason}`
+    : packageName
+
+    // Build the underlying Error
+    super(message)
+
+    // Assign parameters for future use
+    this.packageName = packageName
+    this.functionName = functionName
+    this.reason = reason
+
+    // Set the prototype to AccountsError so "instanceof AccountsError" returns true
+    Object.setPrototypeOf(this, AccountsError.prototype);
+
+    // Recapture the stack trace to avoid this function to be in it
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, this.constructor);
+    } else { 
+      this.stack = (new Error(message)).stack; 
+    }
+
+  }
+}

--- a/packages/error/src/accounts-error.ts
+++ b/packages/error/src/accounts-error.ts
@@ -1,25 +1,21 @@
 export default class AccountsError extends Error {
-
   public packageName?: string;
 
   public functionName?: string;
 
   public reason?: string;
 
-  constructor(packageName?: string, functionName?: string, reason?: string){
-
+  constructor(packageName?: string, functionName?: string, reason?: string) {
     // Build Error message from parameters
-    const message = reason 
-    ? `[ Accounts - ${packageName} ] ${functionName} : ${reason}`
-    : packageName
+    const message = reason ? `[ Accounts - ${packageName} ] ${functionName} : ${reason}` : packageName;
 
     // Build the underlying Error
-    super(message)
+    super(message);
 
     // Assign parameters for future use
-    this.packageName = packageName
-    this.functionName = functionName
-    this.reason = reason
+    this.packageName = packageName;
+    this.functionName = functionName;
+    this.reason = reason;
 
     // Set the prototype to AccountsError so "instanceof AccountsError" returns true
     Object.setPrototypeOf(this, AccountsError.prototype);
@@ -27,9 +23,8 @@ export default class AccountsError extends Error {
     // Recapture the stack trace to avoid this function to be in it
     if (typeof Error.captureStackTrace === 'function') {
       Error.captureStackTrace(this, this.constructor);
-    } else { 
-      this.stack = (new Error(message)).stack; 
+    } else {
+      this.stack = new Error(message).stack;
     }
-
   }
 }

--- a/packages/error/src/index.ts
+++ b/packages/error/src/index.ts
@@ -1,1 +1,1 @@
-export { default } from './accounts-error'
+export { default } from './accounts-error';

--- a/packages/error/src/index.ts
+++ b/packages/error/src/index.ts
@@ -1,0 +1,1 @@
+export { default } from './accounts-error'

--- a/packages/error/tsconfig.json
+++ b/packages/error/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./lib",
+    "typeRoots": [
+      "node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "__tests__",
+    "lib"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@accounts/tslint-config-accounts@0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@accounts/tslint-config-accounts/-/tslint-config-accounts-0.0.6.tgz#d2ab1480f0aff7c911b2bea9fb924d7f04328931"
+"@accounts/tslint-config-accounts@0.0.9":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@accounts/tslint-config-accounts/-/tslint-config-accounts-0.0.9.tgz#a2073361c4127ba7c8662cd72e08a28a794a44df"
   dependencies:
     tslint-config-prettier "^1.1.0"
     tslint-eslint-rules "^4.1.1"


### PR DESCRIPTION
This is a first implementation of the AccountsError package.

````ts
new AccountsError('PasswordService','authenticate','no user match tokens')
// message => '[ Accounts - PasswordService ] authenticate : no user match tokens'

new AccountsError('no user match tokens')
// message => 'no user match tokens'
````

As the error code and login info is not used yet, I removed the code concerning them so we can implement it accordingly with the current state