### PR TITLE
Fix HookListener and SendMailType definitions

### DIFF
--- a/packages/server/src/types/send-mail-type.ts
+++ b/packages/server/src/types/send-mail-type.ts
@@ -1,1 +1,1 @@
-export type SendMailType = (mail: object) => Promise<void>;
+export type SendMailType = (mail: any) => Promise<void>;

--- a/packages/types/src/types/hook-listener.ts
+++ b/packages/types/src/types/hook-listener.ts
@@ -1,1 +1,1 @@
-export type HookListener = (event?: object) => void;
+export type HookListener = (event?: any) => void;


### PR DESCRIPTION
The `object` type does not let a user access the subfields of an object on strict mode so better use any here