### PR TITLE
Pass some context to the login hooks

### DIFF
--- a/packages/server/__tests__/account-server.ts
+++ b/packages/server/__tests__/account-server.ts
@@ -166,17 +166,17 @@ describe('AccountsServer', () => {
   describe('hooks', () => {
     const connectionInfo = {
       userAgent: 'user-agent-test',
-      ip: 'ip-test'
+      ip: 'ip-test',
     };
-    const user = { id: 'id-test' };
     it('ServerHooks.LoginSuccess', async () => {
+      const user = { id: 'id-test' };
       const hookSpy = jest.fn(() => null);
       const services = {
         password: {
           setStore: jest.fn(),
-          authenticate: jest.fn(() => Promise.resolve(user))
-        }
-      }
+          authenticate: jest.fn(() => Promise.resolve(user)),
+        },
+      };
       const accountsServer = new AccountsServer(
         {
           db: {
@@ -189,19 +189,20 @@ describe('AccountsServer', () => {
       accountsServer.on(ServerHooks.LoginSuccess, hookSpy);
       await accountsServer.loginWithService('password', { key: 'value' }, connectionInfo);
       expect(hookSpy).toHaveBeenCalledWith({
-        service: "password",
+        service: 'password',
         connection: connectionInfo,
-        user
+        user,
       });
     });
 
     it('ServerHooks.LoginError', async () => {
+      const user = { id: 'id-test' };
       const services = {
         password: {
           setStore: jest.fn(),
-          authenticate: jest.fn(() => Promise.resolve(user))
-        }
-      }
+          authenticate: jest.fn(() => Promise.resolve(user)),
+        },
+      };
       const hookSpy = jest.fn(() => null);
       const accountsServer = new AccountsServer(
         {
@@ -222,9 +223,9 @@ describe('AccountsServer', () => {
         // nothing to do
       }
       expect(hookSpy).toHaveBeenCalledWith({
-        service: "password",
+        service: 'password',
         connection: connectionInfo,
-        user
+        user,
       });
     });
 

--- a/packages/server/__tests__/account-server.ts
+++ b/packages/server/__tests__/account-server.ts
@@ -165,7 +165,18 @@ describe('AccountsServer', () => {
 
   describe('hooks', () => {
     it('ServerHooks.LoginSuccess', async () => {
+      const connectionInfo = {
+        userAgent: 'user-agent-test',
+        ip: 'ip-test'
+      };
+      const user = { id: 'id-test' };
       const hookSpy = jest.fn(() => null);
+      const services = {
+        password: {
+          setStore: jest.fn(),
+          authenticate: jest.fn(() => Promise.resolve(user))
+        }
+      }
       const accountsServer = new AccountsServer(
         {
           db: {
@@ -173,36 +184,39 @@ describe('AccountsServer', () => {
           } as any,
           tokenSecret: 'secret',
         },
-        {}
+        services
       );
       accountsServer.on(ServerHooks.LoginSuccess, hookSpy);
-
-      await accountsServer.loginWithUser({} as any, {});
-      expect(hookSpy).toBeCalled();
+      await accountsServer.loginWithService('password', { key: 'value' }, connectionInfo);
+      expect(hookSpy).toHaveBeenCalledWith({
+        service: "password",
+        connection: connectionInfo,
+        user
+      });
     });
 
-    it('ServerHooks.LoginError', async () => {
-      const hookSpy = jest.fn(() => null);
-      const accountsServer = new AccountsServer(
-        {
-          db: {
-            createSession: () => {
-              throw new Error('Could not create session');
-            },
-          } as any,
-          tokenSecret: 'secret',
-        },
-        {}
-      );
-      accountsServer.on(ServerHooks.LoginError, hookSpy);
+    // it('ServerHooks.LoginError', async () => {
+    //   const hookSpy = jest.fn(() => null);
+    //   const accountsServer = new AccountsServer(
+    //     {
+    //       db: {
+    //         createSession: () => {
+    //           throw new Error('Could not create session');
+    //         },
+    //       } as any,
+    //       tokenSecret: 'secret',
+    //     },
+    //     {}
+    //   );
+    //   accountsServer.on(ServerHooks.LoginError, hookSpy);
 
-      try {
-        await accountsServer.loginWithUser({} as any, {});
-      } catch (e) {
-        // nothing to do
-      }
-      expect(hookSpy).toBeCalled();
-    });
+    //   try {
+    //     await accountsServer.loginWithUser({} as any, {});
+    //   } catch (e) {
+    //     // nothing to do
+    //   }
+    //   expect(hookSpy).toBeCalled();
+    // });
 
     it('ServerHooks.LogoutSuccess', async () => {
       const user = {

--- a/packages/server/src/accounts-server.ts
+++ b/packages/server/src/accounts-server.ts
@@ -108,7 +108,7 @@ export class AccountsServer {
       hooksInfo.user = user;
 
       // Let the user validate the login attempt
-      await this.hooks.emitSerial(ServerHooks.Login, hooksInfo);
+      await this.hooks.emitSerial(ServerHooks.ValidateLogin, hooksInfo);
       const loginResult = await this.loginWithUser(user, infos);
       this.hooks.emit(ServerHooks.LoginSuccess, hooksInfo);
       return loginResult;

--- a/packages/server/src/utils/server-hooks.ts
+++ b/packages/server/src/utils/server-hooks.ts
@@ -1,5 +1,5 @@
 export const ServerHooks = {
-  Login: 'Login',
+  ValidateLogin: 'ValidateLogin',
   LoginSuccess: 'LoginSuccess',
   LoginError: 'LoginError',
   LogoutSuccess: 'LogoutSuccess',


### PR DESCRIPTION
- `ServerHooks.LoginSuccess`
- `ServerHooks.LoginError`

With this change the 2 hooks will receive the following infos:
```
{
// The service name, such as “password” or “twitter”.
service
// The connection informations <ConnectionInformations>
connection
// The user object if set
user
}
```

I also renamed the `ServerHooks.Login` to `ServerHooks.ValidateLogin` because we let the user the ability to validate the current user on the login flow.