### PR TITLE
Only refresh the tokens if refresh token is not expired on the client

### DIFF
--- a/packages/client/src/accounts-client.ts
+++ b/packages/client/src/accounts-client.ts
@@ -233,8 +233,8 @@ export class AccountsClient {
 
         const decodedAccessToken = jwtDecode(accessToken) as any;
         const decodedRefreshToken = jwtDecode(refreshToken) as any;
-        // See if accessToken is expired
-        if (decodedAccessToken.exp < currentTime) {
+        // See if accessToken is expired and refresh token is not expired
+        if (decodedAccessToken.exp < currentTime && decodedRefreshToken.exp > currentTime) {
           // Request a new token pair
           const refreshedSession: LoginReturnType = await this.transport.refreshTokens(
             accessToken,


### PR DESCRIPTION
Currently we are trying to refresh the tokens even if the refresh token is expired which gave an error from the server as a response.
Quick fix for now on the current client implementation. Will also add it to the client refactor branch.