### PR TITLE
feat: @authenticated directive

### DIFF
--- a/packages/graphql-api/README.md
+++ b/packages/graphql-api/README.md
@@ -49,11 +49,11 @@ const typeDefs = [
   type Query {
     myQuery: String
   }
-  
+
   type Mutation {
     myMutation: String
   }
-  
+
   schema {
       query: Query,
       mutation: Mutation

--- a/packages/graphql-api/README.md
+++ b/packages/graphql-api/README.md
@@ -31,18 +31,19 @@ const accountsServer = new AccountsServer({
 });
 ```
 
-Next, import `createJSAccountsGraphQL` method from this package, and run it with your `AccountsServer`:
+Next, import `createAccountsGraphQL` method from this package, and run it with your `AccountsServer`:
 
 ```js
-import { createJSAccountsGraphQL } from '@accounts/graphql-api';
+import { createAccountsGraphQL } from '@accounts/graphql-api';
 
-const accountsGraphQL = createJSAccountsGraphQL(accountsServer);
+const accountsGraphQL = createAccountsGraphQL(accountsServer);
 ```
 
-Now, add `accountsGraphQL.schema` to your schema definition (just before using it with `makeExecutableSchema`), and use `accountsGraphQL.extendWithResolvers` to extend your resolvers object, for example:
+Now, add `accountsGraphQL.typeDefs` to your schema definition (just before using it with `makeExecutableSchema`), and extend your resolvers object with `accountsGraphQL.resolvers`, for example:
 
 ```js
 import { makeExecutableSchema } from 'graphql-tools';
+import { merge } from 'lodash';
 
 const typeDefs = [
   `
@@ -59,7 +60,7 @@ const typeDefs = [
       mutation: Mutation
   }
   `,
-  accountsGraphQL.schema,
+  accountsGraphQL.typeDefs,
 ];
 
 let myResolvers = {
@@ -71,10 +72,8 @@ let myResolvers = {
   },
 };
 
-const resolversWithAccounts = accountsGraphQL.extendWithResolvers(myResolvers);
-
 const schema = makeExecutableSchema({
-  resolvers,
+  resolvers: merge(accountsGraphQL.resolvers, myResolvers),
   typeDefs,
 });
 ```
@@ -82,14 +81,17 @@ const schema = makeExecutableSchema({
 The last step is to extend your `graphqlExpress` with a context middleware, that extracts the authentication token from the HTTP request, so AccountsServer will automatically validate it:
 
 ```js
-import { JSAccountsContext } from '@accounts/graphql-api';
+import { accountsContext } from '@accounts/graphql-api';
 
 app.use(
   GRAPHQL_ROUTE,
   bodyParser.json(),
   graphqlExpress(request => {
     return {
-      context: JSAccountsContext(request),
+      context: {
+        ...accountsContext(request),
+        // your context
+      },
       schema,
     };
   })
@@ -131,7 +133,7 @@ These are the available customizations:
 - `extend` (boolean) - whether to add `extend` before the root type declaration, default: `true`.
 - `withSchemaDefinition` (boolean): whether to add `schema { ... }` declaration to the generation schema, default: `false`.
 
-Pass a second object to `createJSAccountsGraphQL`, for example:
+Pass a second object to `createAccountsGraphQL`, for example:
 
 ```js
 const myCustomGraphQLAccounts = createSchemaWithAccounts(accountsServer, {
@@ -140,10 +142,10 @@ const myCustomGraphQLAccounts = createSchemaWithAccounts(accountsServer, {
 });
 ```
 
-Another possible customization is to modify the name of the authentication header, use it with `JSAccountsContext` (the default is `Authorization`):
+Another possible customization is to modify the name of the authentication header, use it with `accountsContext` (the default is `Authorization`):
 
 ```js
-context: JSAccountsContext(request, 'MyCustomHeader');
+context: accountsContext(request, 'MyCustomHeader');
 ```
 
 ## Extending `User`

--- a/packages/graphql-api/package.json
+++ b/packages/graphql-api/package.json
@@ -28,6 +28,7 @@
     "graphql": "^0.13.2",
     "graphql-code-generator": "^0.10.0",
     "graphql-codegen-typescript-template": "^0.10.0",
+    "graphql-tools": "^3.0.4",
     "lodash": "4.17.10",
     "nock": "9.0.2",
     "ts-node": "7.0.0"

--- a/packages/graphql-api/src/index.ts
+++ b/packages/graphql-api/src/index.ts
@@ -1,5 +1,5 @@
 import { createAccountsGraphQL } from './schema-builder';
 import { authenticated } from './utils/authenticated-resolver';
-import { JSAccountsContext } from './utils/context-builder';
+import { accountsContext } from './utils/context-builder';
 
-export { createAccountsGraphQL, authenticated, JSAccountsContext };
+export { createAccountsGraphQL, authenticated, accountsContext };

--- a/packages/graphql-api/src/index.ts
+++ b/packages/graphql-api/src/index.ts
@@ -1,5 +1,5 @@
-import { createJSAccountsGraphQL } from './schema-builder';
+import { createAccountsGraphQL } from './schema-builder';
 import { authenticated } from './utils/authenticated-resolver';
 import { JSAccountsContext } from './utils/context-builder';
 
-export { createJSAccountsGraphQL, authenticated, JSAccountsContext };
+export { createAccountsGraphQL, authenticated, JSAccountsContext };

--- a/packages/graphql-api/src/schema-builder.ts
+++ b/packages/graphql-api/src/schema-builder.ts
@@ -5,7 +5,7 @@ import { impersonate } from './resolvers/impersonate';
 import { getUser } from './resolvers/get-user';
 import { User } from './resolvers/user';
 import { mutations } from './graphql/mutations';
-import { typeDefs } from './graphql/types';
+import { typeDefs as accountsTypeDefs } from './graphql/types';
 import { queries } from './graphql/queries';
 import { logout } from './resolvers/logout';
 import { registerPassword } from './resolvers/register-user';
@@ -17,6 +17,7 @@ import { changePassword } from './resolvers/change-password';
 import { twoFactorSet, twoFactorUnset, twoFactorSecret } from './resolvers/two-factor';
 import { authenticated } from './utils/authenticated-resolver';
 import { MutationResolvers, QueryResolvers } from './types/graphql';
+import { createAuthenticatedDirective } from './utils/authenticated-directive';
 
 export interface SchemaGenerationOptions {
   rootQueryName?: string;
@@ -41,8 +42,8 @@ export const createJSAccountsGraphQL = (
     ...schemaOptionsUser,
   };
 
-  const schema = `
-  ${typeDefs}
+  const typeDefs = `
+  ${accountsTypeDefs}
 
   ${schemaOptions.extend ? 'extend ' : ''}type ${schemaOptions.rootQueryName} {
     ${queries}
@@ -96,8 +97,10 @@ export const createJSAccountsGraphQL = (
   };
 
   return {
-    schema,
+    typeDefs,
     resolvers,
-    extendWithResolvers: (resolversObject: any) => [...resolversObject, resolvers],
+    schemaDirectives: {
+      authenticated: createAuthenticatedDirective(accountsServer),
+    },
   };
 };

--- a/packages/graphql-api/src/schema-builder.ts
+++ b/packages/graphql-api/src/schema-builder.ts
@@ -33,7 +33,7 @@ const defaultSchemaOptions = {
   withSchemaDefinition: false,
 };
 
-export const createJSAccountsGraphQL = (
+export const createAccountsGraphQL = (
   accountsServer: AccountsServer,
   schemaOptionsUser?: SchemaGenerationOptions
 ) => {
@@ -100,7 +100,7 @@ export const createJSAccountsGraphQL = (
     typeDefs,
     resolvers,
     schemaDirectives: {
-      authenticated: createAuthenticatedDirective(accountsServer),
+      auth: createAuthenticatedDirective(accountsServer),
     },
   };
 };

--- a/packages/graphql-api/src/utils/authenticated-directive.ts
+++ b/packages/graphql-api/src/utils/authenticated-directive.ts
@@ -1,0 +1,17 @@
+import { authenticated } from './authenticated-resolver';
+import { SchemaDirectiveVisitor } from 'graphql-tools';
+import { AccountsServer } from '@accounts/server';
+
+export const createAuthenticatedDirective: any = (accounts: AccountsServer) => {
+  return class AuthenticatedDirective extends SchemaDirectiveVisitor {
+    public visitFieldDefinition(field: any) {
+      field.resolve = authenticated(accounts, field.resolve);
+    }
+    public visitObject(object: any) {
+      const fields = object.getFields();
+      Object.keys(fields).forEach((key: any) => {
+        fields[key].resolve = authenticated(accounts, fields[key].resolve);
+      });
+    }
+  };
+};

--- a/packages/graphql-api/src/utils/authenticated-resolver.ts
+++ b/packages/graphql-api/src/utils/authenticated-resolver.ts
@@ -16,13 +16,15 @@ export const authenticated = (Accounts: AccountsServer, func: any) => async (
     throw new Error('Unable to find authorization token in request');
   }
 
-  const userObject = await Accounts.resumeSession(authToken);
+  if (!context.user) {
+    const userObject = await Accounts.resumeSession(authToken);
 
-  if (userObject === null) {
-    throw new Error('Invalid or expired token!');
+    if (userObject === null) {
+      throw new Error('Invalid or expired token!');
+    }
+
+    context.user = userObject;
   }
-
-  context.user = userObject;
 
   return func(root, args, context, info);
 };

--- a/packages/graphql-api/src/utils/context-builder.ts
+++ b/packages/graphql-api/src/utils/context-builder.ts
@@ -10,7 +10,10 @@ export const getUA = (req: IncomingMessage) => {
   return userAgent;
 };
 
-export const accountsContext = (request: IncomingMessage, headerName = 'Authorization') => ({
+export const accountsContext = (
+  request: IncomingMessage,
+  headerName = 'accounts-access-token'
+) => ({
   authToken: request.headers[headerName] || request.headers[headerName.toLowerCase()],
   userAgent: getUA(request),
   ip: getClientIp(request),

--- a/packages/graphql-api/src/utils/context-builder.ts
+++ b/packages/graphql-api/src/utils/context-builder.ts
@@ -10,7 +10,7 @@ export const getUA = (req: IncomingMessage) => {
   return userAgent;
 };
 
-export const JSAccountsContext = (request: IncomingMessage, headerName = 'Authorization') => ({
+export const accountsContext = (request: IncomingMessage, headerName = 'Authorization') => ({
   authToken: request.headers[headerName] || request.headers[headerName.toLowerCase()],
   userAgent: getUA(request),
   ip: getClientIp(request),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2359,7 +2359,7 @@ graphql-tag@^1.1.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-1.3.2.tgz#7abb3a8fd9f3415d07163314ed237061c785b759"
 
-graphql-tools@3.0.4:
+graphql-tools@3.0.4, graphql-tools@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-3.0.4.tgz#d08aa75db111d704cba05d92afd67ec5d1dc6b24"
   dependencies:


### PR DESCRIPTION
Modifies createJSAccountsGraphQL to return typeDefs (renamed from schema), resolvers, and schemaDirectives.

Created AuthenticatedDirective which wraps all graphql objects or fields annotated with @authenticated.

**Todo**

- [x] Update documentation
- [ ] Update example
- [x] Cache authentication check. A request doesn't need to run through the authenticated logic for each type or field annotated with the directive, just once and caching the result should suffice. 

**Questions**

- Should `@authenticated` to be renamed to `@auth` to be more concise?
- Should `createJSAccountsGraphQL` be renamed to `createAccountsGraphQL`?

**Related issues**: #362   