### PR TITLE
Fix infinite loop issue during token refresh for graphql-client

### DIFF
--- a/packages/graphql-client/package.json
+++ b/packages/graphql-client/package.json
@@ -36,7 +36,6 @@
   },
   "dependencies": {
     "@accounts/client": "^0.3.0-beta.20",
-    "@accounts/common": "0.1.0-alpha.58382c10",
     "@accounts/types": "^0.3.0-beta.20",
     "graphql-tag": "^1.1.2"
   }

--- a/packages/graphql-client/src/graphql-client.ts
+++ b/packages/graphql-client/src/graphql-client.ts
@@ -139,7 +139,12 @@ export default class GraphQLClient implements TransportInterface {
   }
 
   private async mutate(mutation: any, resultField: any, variables: any) {
-    const tokens = (await this.client.refreshSession()) || { accessToken: '' };
+    // If we are executiong a refresh token mutation do not call refress session again
+    // otherwise it will end up in an infinite loop
+    const tokens =
+      mutation === refreshTokensMutation
+        ? await this.client.getTokens()
+        : await this.client.refreshSession();
 
     try {
       const { data } = await this.options.graphQLClient.mutate({
@@ -147,7 +152,7 @@ export default class GraphQLClient implements TransportInterface {
         variables,
         context: {
           headers: {
-            'accounts-access-token': tokens.accessToken,
+            'accounts-access-token': tokens ? tokens.accessToken : '',
           },
         },
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,6 @@
 # yarn lockfile v1
 
 
-"@accounts/common@0.1.0-alpha.58382c10":
-  version "0.1.0-alpha.58382c10"
-  resolved "https://registry.yarnpkg.com/@accounts/common/-/common-0.1.0-alpha.58382c10.tgz#b70db9a29a033fb2f2636d7b5f3bb568ffbae7c8"
-  dependencies:
-    lodash "^4.16.4"
-
 "@accounts/tslint-config-accounts@0.0.9":
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/@accounts/tslint-config-accounts/-/tslint-config-accounts-0.0.9.tgz#a2073361c4127ba7c8662cd72e08a28a794a44df"
@@ -3885,7 +3879,7 @@ lodash@4.16.4:
   version "4.16.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.16.4.tgz#01ce306b9bad1319f2a5528674f88297aeb70127"
 
-lodash@4.17.10, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.16.4, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1:
+lodash@4.17.10, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 


### PR DESCRIPTION
If we are executiong a refresh token mutation do not call refress session again otherwise it will end up in an infinite loop