### PR TITLE
Required reason token for the database interface

### DIFF
--- a/packages/database-mongo/__tests__/index.ts
+++ b/packages/database-mongo/__tests__/index.ts
@@ -733,7 +733,7 @@ describe('Mongo', () => {
   describe('addResetPasswordToken', () => {
     it('should add a token', async () => {
       const userId = await databaseTests.database.createUser(user);
-      await databaseTests.database.addResetPasswordToken(userId, 'john@doe.com', 'token');
+      await databaseTests.database.addResetPasswordToken(userId, 'john@doe.com', 'token', 'reset');
       const retUser = await databaseTests.database.findUserById(userId);
       expect(retUser.services.password.reset.length).toEqual(1);
       expect(retUser.services.password.reset[0].address).toEqual('john@doe.com');

--- a/packages/database-mongo/src/mongo.ts
+++ b/packages/database-mongo/src/mongo.ts
@@ -398,7 +398,7 @@ export class Mongo implements DatabaseInterface {
     userId: string,
     email: string,
     token: string,
-    reason: string = 'reset'
+    reason: string
   ): Promise<void> {
     await this.collection.update(
       { _id: userId },

--- a/packages/password/__tests__/accounts-password.ts
+++ b/packages/password/__tests__/accounts-password.ts
@@ -419,7 +419,7 @@ describe('AccountsPassword', () => {
       } as any;
       set(password.server, 'options.emailTemplates', {});
       await password.sendResetPasswordEmail(email);
-      expect(addResetPasswordToken.mock.calls[0].length).toBe(3);
+      expect(addResetPasswordToken.mock.calls[0].length).toBe(4);
       expect(prepareMail.mock.calls[0].length).toBe(6);
       expect(sendMail.mock.calls[0].length).toBe(1);
     });

--- a/packages/password/package.json
+++ b/packages/password/package.json
@@ -10,7 +10,6 @@
     "precompile": "npm run clean",
     "compile": "tsc",
     "prepublishOnly": "npm run compile",
-    "test": "npm run test",
     "testonly": "jest --coverage",
     "coverage": "jest --coverage"
   },

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -294,7 +294,7 @@ export default class AccountsPassword implements AuthenticationService {
     }
     address = getFirstUserEmail(user, address);
     const token = generateRandomToken();
-    await this.db.addResetPasswordToken(user.id, address, token);
+    await this.db.addResetPasswordToken(user.id, address, token, 'reset');
 
     const resetPasswordMail = this.server.prepareMail(
       address,

--- a/packages/types/src/types/database-interface.ts
+++ b/packages/types/src/types/database-interface.ts
@@ -36,7 +36,7 @@ export interface DatabaseInterface extends DatabaseInterfaceSessions {
     userId: string,
     email: string,
     token: string,
-    reason?: string
+    reason: string
   ): Promise<void>;
 
   setResetPassword(


### PR DESCRIPTION
If we let it like this we will end up setting this string in all the database implementation, I think it's cleaner to make the parameter mandatory.