### PR TITLE
Fix apollo-link-accounts types

### DIFF
--- a/packages/apollo-link-accounts/package.json
+++ b/packages/apollo-link-accounts/package.json
@@ -21,6 +21,7 @@
   "license": "MIT",
   "devDependencies": {
     "@accounts/client": "^0.3.0-beta.21",
+    "apollo-link": "^1.2.2",
     "rimraf": "2.6.2"
   },
   "dependencies": {

--- a/packages/apollo-link-accounts/src/index.ts
+++ b/packages/apollo-link-accounts/src/index.ts
@@ -1,7 +1,8 @@
 import { setContext } from 'apollo-link-context';
+import { ApolloLink } from 'apollo-link';
 import { AccountsClient } from '@accounts/client';
 
-export const accountsLink = (accountsClient: AccountsClient) => {
+export const accountsLink = (accountsClient: AccountsClient): ApolloLink => {
   return setContext(async (_, { headers }) => {
     const tokens = await accountsClient.refreshSession();
     return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -184,9 +184,13 @@
     "@types/events" "*"
     "@types/node" "*"
 
-"@types/node@*", "@types/node@9.6.15", "@types/node@9.6.7", "@types/node@^9.4.6":
+"@types/node@*", "@types/node@9.6.15", "@types/node@^9.4.6":
   version "9.6.15"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.15.tgz#8a5a313ea0a43a95277235841be5d3f5fb3dfeda"
+
+"@types/node@9.6.7":
+  version "9.6.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.7.tgz#5f3816d1db2155edcde1b2e3aa5d0e5c520cb564"
 
 "@types/oauth@0.9.0":
   version "0.9.0"


### PR DESCRIPTION
Right now when we compile apollo-link-accounts we have this file (`index.d.ts`) which is generated and failing when you integrate it to your project.
```ts
import { AccountsClient } from '@accounts/client';
export declare const accountsLink: (accountsClient: AccountsClient) => import("../../../node_modules/apollo-link-context/node_modules/apollo-link/lib/link").ApolloLink;
```

after the fix:
```ts
import { ApolloLink } from 'apollo-link';
import { AccountsClient } from '@accounts/client';
export declare const accountsLink: (accountsClient: AccountsClient) => ApolloLink;
```