### PR TITLE
feat: export graphql-api types

### DIFF
--- a/packages/graphql-api/src/index.ts
+++ b/packages/graphql-api/src/index.ts
@@ -3,3 +3,6 @@ import { authenticated } from './utils/authenticated-resolver';
 import { accountsContext } from './utils/context-builder';
 
 export { createAccountsGraphQL, authenticated, accountsContext };
+
+export * from './types/graphql';
+export * from './types';


### PR DESCRIPTION
We need to extend from `IResolverContext` and merge in our own properties. So I wonder maybe `IResolverContext` should be exported.