### PR TITLE
Update @accounts/password peer dep

### DIFF
--- a/packages/password/package.json
+++ b/packages/password/package.json
@@ -39,6 +39,6 @@
     "rimraf": "2.6.2"
   },
   "peerDependencies": {
-    "@accounts/server": "^0.1.0-beta.0"
+    "@accounts/server": "^0.3.0-beta.0"
   }
 }


### PR DESCRIPTION
As is, you get this warning with latest `@accounts/server`:

```
npm WARN @accounts/password@0.3.0-beta.21 requires a peer of @accounts/serve
r@^0.1.0-beta.0 but none is installed. You must install peer dependencies yo
urself.
```