### PR TITLE
Do not fetch the user on logout

### DIFF
--- a/packages/server/__tests__/account-server.ts
+++ b/packages/server/__tests__/account-server.ts
@@ -105,32 +105,6 @@ describe('AccountsServer', () => {
   });
 
   describe('logout', () => {
-    it('throws error if user is not found', async () => {
-      const accountsServer = new AccountsServer(
-        {
-          db: {
-            findSessionByToken: () =>
-              Promise.resolve({
-                id: '456',
-                valid: true,
-                userId: '123',
-              }),
-            findUserById: () => Promise.resolve(null),
-          } as any,
-          tokenSecret: 'secret1',
-        },
-        {}
-      );
-      try {
-        const { accessToken } = accountsServer.createTokens('456');
-        await accountsServer.logout(accessToken);
-        throw new Error();
-      } catch (err) {
-        const { message } = err;
-        expect(message).toEqual('User not found');
-      }
-    });
-
     it('invalidates session', async () => {
       const invalidateSession = jest.fn(() => Promise.resolve());
       const user = {
@@ -147,7 +121,6 @@ describe('AccountsServer', () => {
                 valid: true,
                 userId: '123',
               }),
-            findUserById: () => Promise.resolve(user),
             invalidateSession,
           } as any,
           tokenSecret: 'secret1',

--- a/packages/server/src/accounts-server.ts
+++ b/packages/server/src/accounts-server.ts
@@ -340,15 +340,8 @@ Please change it with a strong random token.`);
       const session: Session = await this.findSessionByAccessToken(accessToken);
 
       if (session.valid) {
-        const user = await this.db.findUserById(session.userId);
-
-        if (!user) {
-          throw new Error('User not found');
-        }
-
         await this.db.invalidateSession(session.id);
         this.hooks.emit(ServerHooks.LogoutSuccess, {
-          user: this.sanitizeUser(user),
           session,
           accessToken,
         });


### PR DESCRIPTION
This will allow us to save one query from the database.
You can access the user inside `ServerHooks.LogoutSuccess` event with `session.userId` and fetching it from the database.