### PR TITLE
Fix to accounts link sending null string as access token

### DIFF
--- a/packages/apollo-link-accounts/src/index.ts
+++ b/packages/apollo-link-accounts/src/index.ts
@@ -3,13 +3,17 @@ import { ApolloLink } from 'apollo-link';
 import { AccountsClient } from '@accounts/client';
 
 export const accountsLink = (accountsClient: AccountsClient): ApolloLink => {
-  return setContext(async (_, { headers }) => {
+  return setContext(async (_, { headers: headersWithoutTokens }) => {
     const tokens = await accountsClient.refreshSession();
+
+    const headers = { ...headersWithoutTokens };
+
+    if (tokens) {
+      headers['accounts-access-token'] = tokens.accessToken;
+    }
+
     return {
-      headers: {
-        ...headers,
-        'accounts-access-token': tokens ? tokens.accessToken : null,
-      },
+      headers,
     };
   });
 };


### PR DESCRIPTION
`'null'` was being sent to the server (rather than `null`) which was throwing errors of bad access token rather than just skipping the check.

Was sending me annoying errors to the client, so I fixed it.