### PR TITLE
Load the user in the context resolver

### DIFF
--- a/packages/e2e/__tests__/servers/server-graphql.ts
+++ b/packages/e2e/__tests__/servers/server-graphql.ts
@@ -85,11 +85,10 @@ export class ServerGraphqlTest implements ServerTestInterface {
     this.apolloServer = new ApolloServer({
       typeDefs: [gql(accountsGraphQL.typeDefs), typeDefs],
       resolvers: merge(accountsGraphQL.resolvers),
-      context: async ({ req }: any) => ({
-        ...(await accountsContext(req, {
+      context: ({ req }: any) =>
+        accountsContext(req, {
           accountsServer: this.accountsServer,
-        })),
-      }),
+        }),
     });
 
     const apolloClient = new ApolloClient({ uri: urlString });

--- a/packages/e2e/__tests__/servers/server-graphql.ts
+++ b/packages/e2e/__tests__/servers/server-graphql.ts
@@ -85,8 +85,10 @@ export class ServerGraphqlTest implements ServerTestInterface {
     this.apolloServer = new ApolloServer({
       typeDefs: [gql(accountsGraphQL.typeDefs), typeDefs],
       resolvers: merge(accountsGraphQL.resolvers),
-      context: ({ req }: any) => ({
-        ...accountsContext(req),
+      context: async ({ req }: any) => ({
+        ...(await accountsContext(req, {
+          accountsServer: this.accountsServer,
+        })),
       }),
     });
 

--- a/packages/graphql-api/src/resolvers/get-user.ts
+++ b/packages/graphql-api/src/resolvers/get-user.ts
@@ -6,7 +6,5 @@ export const getUser = (accountsServer: AccountsServer): QueryResolvers.GetUserR
   __: null,
   context
 ) => {
-  const { authToken } = context;
-
-  return authToken && accountsServer.resumeSession(authToken);
+  return context.user;
 };

--- a/packages/graphql-api/src/utils/authenticated-resolver.ts
+++ b/packages/graphql-api/src/utils/authenticated-resolver.ts
@@ -10,20 +10,8 @@ export const authenticated = (Accounts: AccountsServer, func: any) => async (
     return func(root, args, context, info);
   }
 
-  const authToken = context.authToken;
-
-  if (!authToken || authToken === '' || authToken === null) {
-    throw new Error('Unable to find authorization token in request');
-  }
-
-  if (!context.user) {
-    const userObject = await Accounts.resumeSession(authToken);
-
-    if (userObject === null) {
-      throw new Error('Invalid or expired token!');
-    }
-
-    context.user = userObject;
+  if (!context.userId && !context.user) {
+    throw new Error('Unauthorized');
   }
 
   return func(root, args, context, info);


### PR DESCRIPTION
Close #421 
The new context will now be async (breaking change)