### PR TITLE
Feature/additional fields user

### DIFF
--- a/packages/database-mongo/__tests__/index.ts
+++ b/packages/database-mongo/__tests__/index.ts
@@ -13,7 +13,6 @@ const user = {
   username: 'johndoe',
   email: 'john@doe.com',
   password: 'toto',
-  profile: {},
 };
 const session = {
   userId: '123',
@@ -102,39 +101,67 @@ describe('Mongo', () => {
     it('should create a new user', async () => {
       const userId = await databaseTests.database.createUser(user);
       const ret = await databaseTests.database.findUserById(userId);
-      expect(ret._id).toBeTruthy();
-      expect(ret.emails[0].address).toBe(user.email);
-      expect(ret.emails[0].verified).toBe(false);
-      expect(ret.createdAt).toBeTruthy();
-      expect(ret.updatedAt).toBeTruthy();
+      expect(userId).toBeTruthy();
+      expect(ret).toEqual({
+        _id: expect.any(ObjectID),
+        id: expect.any(ObjectID),
+        username: 'johndoe',
+        emails: [
+          {
+            address: user.email,
+            verified: false,
+          },
+        ],
+        services: {
+          password: {
+            bcrypt: 'toto',
+          },
+        },
+        createdAt: expect.any(Number),
+        updatedAt: expect.any(Number),
+      });
+    });
+
+    it('should not overwrite service', async () => {
+      const userId = await databaseTests.database.createUser({
+        ...user,
+        services: 'test',
+      });
+      const ret = await databaseTests.database.findUserById(userId);
+      expect(userId).toBeTruthy();
+      expect(ret!.services).toEqual({
+        password: {
+          bcrypt: 'toto',
+        },
+      });
     });
 
     it('should not set password', async () => {
       const userId = await databaseTests.database.createUser({ email: user.email });
       const ret = await databaseTests.database.findUserById(userId);
-      expect(ret._id).toBeTruthy();
-      expect(ret.services.password).not.toBeTruthy();
+      expect(ret!.id).toBeTruthy();
+      expect(ret!.services!.password).not.toBeTruthy();
     });
 
     it('should not set username', async () => {
       const userId = await databaseTests.database.createUser({ email: user.email });
       const ret = await databaseTests.database.findUserById(userId);
-      expect(ret._id).toBeTruthy();
-      expect(ret.username).not.toBeTruthy();
+      expect(ret!.id).toBeTruthy();
+      expect(ret!.username).not.toBeTruthy();
     });
 
     it('should not set email', async () => {
       const userId = await databaseTests.database.createUser({ username: user.username });
       const ret = await databaseTests.database.findUserById(userId);
-      expect(ret._id).toBeTruthy();
-      expect(ret.emails).not.toBeTruthy();
+      expect(ret!.id).toBeTruthy();
+      expect(ret!.emails).not.toBeTruthy();
     });
 
     it('email should be lowercase', async () => {
       const userId = await databaseTests.database.createUser({ email: 'JohN@doe.com' });
       const ret = await databaseTests.database.findUserById(userId);
-      expect(ret._id).toBeTruthy();
-      expect(ret.emails[0].address).toEqual('john@doe.com');
+      expect(ret!.id).toBeTruthy();
+      expect(ret!.emails![0].address).toEqual('john@doe.com');
     });
 
     it('call options.idProvider', async () => {
@@ -145,8 +172,8 @@ describe('Mongo', () => {
       const userId = await mongoOptions.createUser({ email: 'JohN@doe.com' });
       const ret = await mongoOptions.findUserById(userId);
       expect(userId).toBe('toto');
-      expect(ret._id).toBeTruthy();
-      expect(ret.emails[0].address).toEqual('john@doe.com');
+      expect(ret!.id).toBeTruthy();
+      expect(ret!.emails![0].address).toEqual('john@doe.com');
     });
   });
 

--- a/packages/database-mongo/src/mongo.ts
+++ b/packages/database-mongo/src/mongo.ts
@@ -64,24 +64,26 @@ export class Mongo implements DatabaseInterface {
     });
   }
 
-  public async createUser(options: CreateUser): Promise<string> {
+  public async createUser({
+    password,
+    username,
+    email,
+    ...cleanUser
+  }: CreateUser): Promise<string> {
     const user: MongoUser = {
+      ...cleanUser,
       services: {},
-      profile: {},
       [this.options.timestamps.createdAt]: this.options.dateProvider(),
       [this.options.timestamps.updatedAt]: this.options.dateProvider(),
     };
-    if (options.password) {
-      user.services.password = { bcrypt: options.password };
+    if (password) {
+      user.services.password = { bcrypt: password };
     }
-    if (options.username) {
-      user.username = options.username;
+    if (username) {
+      user.username = username;
     }
-    if (options.email) {
-      user.emails = [{ address: options.email.toLowerCase(), verified: false }];
-    }
-    if (options.profile) {
-      user.profile = options.profile;
+    if (email) {
+      user.emails = [{ address: email.toLowerCase(), verified: false }];
     }
     if (this.options.idProvider) {
       user._id = this.options.idProvider();

--- a/packages/database-mongo/src/types/index.ts
+++ b/packages/database-mongo/src/types/index.ts
@@ -51,4 +51,5 @@ export interface MongoUser {
       verified: boolean;
     }
   ];
+  [key: string]: any;
 }

--- a/packages/password/__tests__/__snapshots__/accounts-password.ts.snap
+++ b/packages/password/__tests__/__snapshots__/accounts-password.ts.snap
@@ -18,8 +18,6 @@ exports[`AccountsPassword authenticate throws when hash not found 1`] = `"User h
 
 exports[`AccountsPassword authenticate throws when user not found 1`] = `"User not found"`;
 
-exports[`AccountsPassword createUser throws if validateNewUser does not pass 1`] = `"User invalid"`;
-
 exports[`AccountsPassword createUser throws on required fields 1`] = `"Username or Email is required"`;
 
 exports[`AccountsPassword createUser throws when email already exists 1`] = `"Email already exists"`;

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -42,7 +42,9 @@ export interface AccountsPasswordOptions {
    */
   passwordEnrollTokenExpiration?: number;
   minimumPasswordLength?: number;
-  validateNewUser?: (user: CreateUser) => Promise<PasswordCreateUserType>;
+  validateNewUser?: (
+    user: PasswordCreateUserType
+  ) => Promise<PasswordCreateUserType> | PasswordCreateUserType;
   validateEmail?(email?: string): boolean;
   validatePassword?(password?: PasswordType): boolean;
   validateUsername?(username?: string): boolean;

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -1,6 +1,5 @@
 import { trim, isEmpty, pick, isString, isPlainObject, find, includes, defer } from 'lodash';
 import {
-  CreateUser,
   User,
   LoginUserIdentity,
   EmailRecord,

--- a/packages/types/src/types/create-user.ts
+++ b/packages/types/src/types/create-user.ts
@@ -1,6 +1,5 @@
 export interface CreateUser {
   username?: string;
   email?: string;
-  profile?: object;
   [additionalKey: string]: any;
 }


### PR DESCRIPTION
Close #394 

We now use the `validateNewUser` function to let the user server modify the user object that will be inserted in the database.

The `validateNewUser` function can be used to invalidate the user based on some custom logic and to add more fields that will be inserted in the database.

⚠️ if the user does not provide the `validateNewUser` function we only allow this fields: `pick(user, ['username', 'email', 'password'])`.

Usage example:
```typescript
const password = new AccountsPassword({
  validateNewUser: user => {
    // Here you can write your custom logic to validate the user
    // First let's validate the user fields
    if (!user.additionalFieldFormClient) {
      throw new Error('additionalFieldFormClient missing');
    }
    if (!user.additionalFieldFormClient.length > 20) {
      throw new Error('additionalFieldFormClient too long');
    }

    // Now let's add some fields to the user
    user.additionalField = 'test';

    // I can still set the profile object
    user.profile = {
      // ... my fields
    };

    // The object that is returned will be inserted in the database
	// So better to be sure the fields we are returning
    return pick(user, [
      'username',
      'email',
      'password',
      'additionalField',
      'profile',
      // My other fields ...
    ]);
  },
});
```

## Breaking changes

- [@accounts/password] `validateNewUser` now **must** return the user.
- we do not support the profile key by default, fields will be inserted in the root level of the user object.
