### PR TITLE
Fix breaking change

### DIFF
--- a/packages/rest-client/src/rest-client.ts
+++ b/packages/rest-client/src/rest-client.ts
@@ -108,10 +108,10 @@ export class RestClient implements TransportInterface {
     return this.authFetch('logout', args, customHeaders);
   }
 
-  public async getUser(accessToken: string, customHeaders?: object): Promise<User> {
+  public async getUser(tokens?: any, customHeaders?: object): Promise<User> {
     const args = {
       method: 'POST',
-      body: JSON.stringify({}),
+      body: JSON.stringify(tokens || {}),
     };
     return this.authFetch('user', args, customHeaders);
   }


### PR DESCRIPTION
commit #420 broke my implementation by 'making accessToken optional', in fact the code change there didn't make it optional, it forced accessToken to undefined by ignoring the argument and replacing with an empty object. This change should safely allow for a nullable argument of any tokens to pass through this module.

server versions used for testing
    "@accounts/mongo": "0.3.0-beta.29",
    "@accounts/password": "0.3.0-beta.29",
    "@accounts/rest-express": "0.3.0-beta.29",