### PR TITLE
User enumeration

### DIFF
--- a/packages/e2e/__tests__/password.ts
+++ b/packages/e2e/__tests__/password.ts
@@ -4,7 +4,6 @@ const user = {
   email: 'johnDoe@gmail.com',
   password: 'notSecure',
 };
-let userId: string;
 
 Object.keys(servers).forEach(key => {
   const server = servers[key];
@@ -15,11 +14,11 @@ Object.keys(servers).forEach(key => {
 
     describe('create a new user', () => {
       it('should create a new user with email and password', async () => {
-        userId = await server.accountsClientPassword.createUser({
+        const userId = await server.accountsClientPassword.createUser({
           email: user.email,
           password: user.password,
         });
-        expect(userId).toBeTruthy();
+        expect(userId).toBeNull();
       });
     });
 
@@ -34,7 +33,7 @@ Object.keys(servers).forEach(key => {
           });
           throw new Error();
         } catch (error) {
-          expect(error.message).toMatch('User not found');
+          expect(error.message).toMatch('Invalid credentials');
         }
       });
 

--- a/packages/graphql-api/src/modules/accounts-password/index.ts
+++ b/packages/graphql-api/src/modules/accounts-password/index.ts
@@ -1,5 +1,6 @@
 import { GraphQLModule } from '@graphql-modules/core';
 import { AccountsPassword } from '@accounts/password';
+import { AccountsServer } from '@accounts/server';
 import TypesTypeDefs from './schema/types';
 import getQueryTypeDefs from './schema/query';
 import getMutationTypeDefs from './schema/mutation';
@@ -10,6 +11,7 @@ import { AccountsRequest } from '../accounts';
 import { mergeGraphQLSchemas } from '@graphql-modules/epoxy';
 
 export interface AccountsPasswordModuleConfig {
+  accountsServer: AccountsServer;
   accountsPassword: AccountsPassword;
   rootQueryName?: string;
   rootMutationName?: string;
@@ -35,6 +37,10 @@ export const AccountsPasswordModule = new GraphQLModule<
       [config.rootMutationName || 'Mutation']: Mutation,
     } as any),
   providers: ({ config }) => [
+    {
+      provide: AccountsServer,
+      useValue: config.accountsServer,
+    },
     {
       provide: AccountsPassword,
       useValue: config.accountsPassword,

--- a/packages/graphql-api/src/modules/accounts-password/resolvers/mutation.ts
+++ b/packages/graphql-api/src/modules/accounts-password/resolvers/mutation.ts
@@ -1,7 +1,8 @@
-import { MutationResolvers } from '../../../types';
 import { ModuleContext } from '@graphql-modules/core';
-import { AccountsModuleContext } from '../../accounts';
 import { AccountsPassword, PasswordCreateUserType } from '@accounts/password';
+import { AccountsServer } from '@accounts/server';
+import { AccountsModuleContext } from '../../accounts';
+import { MutationResolvers } from '../../../types';
 
 export const Mutation: MutationResolvers.Resolvers<ModuleContext<AccountsModuleContext>> = {
   changePassword: async (_, { oldPassword, newPassword }, { user, injector }) => {
@@ -15,7 +16,7 @@ export const Mutation: MutationResolvers.Resolvers<ModuleContext<AccountsModuleC
   },
   createUser: async (_: null, { user }, { injector }) => {
     const userId = await injector.get(AccountsPassword).createUser(user as PasswordCreateUserType);
-    return userId;
+    return injector.get(AccountsServer).options.ambiguousErrorMessages ? null : userId;
   },
   twoFactorSet: async (_, { code, secret }, { user, injector }) => {
     // Make sure user is logged in

--- a/packages/password/__tests__/accounts-password.ts
+++ b/packages/password/__tests__/accounts-password.ts
@@ -3,6 +3,7 @@ import { AccountsPassword } from '../src';
 
 describe('AccountsPassword', () => {
   const server: any = {
+    options: {},
     getHooks: () => ({
       emit: jest.fn(),
     }),

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -22,6 +22,10 @@ import { PasswordCreateUserType, PasswordLoginType, PasswordType, ErrorMessages 
 import { errors } from './errors';
 
 export interface AccountsPasswordOptions {
+  /**
+   * Return ambiguous error messages from login failures to prevent user enumeration. Defaults to true.
+   */
+  ambiguousErrorMessages?: boolean;
   twoFactor?: AccountsTwoFactorOptions;
   passwordHashAlgorithm?: HashAlgorithm;
   /**
@@ -50,6 +54,7 @@ export interface AccountsPasswordOptions {
 }
 
 const defaultOptions = {
+  ambiguousErrorMessages: true,
   minimumPasswordLength: 7,
   // 3 days - 3 * 24 * 60 * 60 * 1000
   verifyEmailTokenExpiration: 259200000,
@@ -427,7 +432,11 @@ export default class AccountsPassword implements AuthenticationService {
 
     // @ts-ignore
     if (!foundUser) {
-      throw new Error(this.options.errors.userNotFound);
+      throw new Error(
+        this.options.ambiguousErrorMessages
+          ? this.options.errors.invalidCredentials
+          : this.options.errors.userNotFound
+      );
     }
 
     const hash = await this.db.findPasswordHash(foundUser.id);

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -280,6 +280,10 @@ export default class AccountsPassword implements AuthenticationService {
 
     const user = await this.db.findUserByEmail(address);
     if (!user) {
+      // To prevent user enumeration we fail silently
+      if (this.options.ambiguousErrorMessages) {
+        return;
+      }
       throw new Error(this.options.errors.userNotFound);
     }
     const token = generateRandomToken();
@@ -311,6 +315,10 @@ export default class AccountsPassword implements AuthenticationService {
 
     const user = await this.db.findUserByEmail(address);
     if (!user) {
+      // To prevent user enumeration we fail silently
+      if (this.options.ambiguousErrorMessages) {
+        return;
+      }
       throw new Error(this.options.errors.userNotFound);
     }
     const token = generateRandomToken();

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -22,10 +22,6 @@ import { PasswordCreateUserType, PasswordLoginType, PasswordType, ErrorMessages 
 import { errors } from './errors';
 
 export interface AccountsPasswordOptions {
-  /**
-   * Return ambiguous error messages from login failures to prevent user enumeration. Defaults to true.
-   */
-  ambiguousErrorMessages?: boolean;
   twoFactor?: AccountsTwoFactorOptions;
   passwordHashAlgorithm?: HashAlgorithm;
   /**
@@ -54,7 +50,6 @@ export interface AccountsPasswordOptions {
 }
 
 const defaultOptions = {
-  ambiguousErrorMessages: true,
   minimumPasswordLength: 7,
   // 3 days - 3 * 24 * 60 * 60 * 1000
   verifyEmailTokenExpiration: 259200000,
@@ -281,7 +276,7 @@ export default class AccountsPassword implements AuthenticationService {
     const user = await this.db.findUserByEmail(address);
     if (!user) {
       // To prevent user enumeration we fail silently
-      if (this.options.ambiguousErrorMessages) {
+      if (this.server.options.ambiguousErrorMessages) {
         return;
       }
       throw new Error(this.options.errors.userNotFound);
@@ -316,7 +311,7 @@ export default class AccountsPassword implements AuthenticationService {
     const user = await this.db.findUserByEmail(address);
     if (!user) {
       // To prevent user enumeration we fail silently
-      if (this.options.ambiguousErrorMessages) {
+      if (this.server.options.ambiguousErrorMessages) {
         return;
       }
       throw new Error(this.options.errors.userNotFound);
@@ -441,7 +436,7 @@ export default class AccountsPassword implements AuthenticationService {
     // @ts-ignore
     if (!foundUser) {
       throw new Error(
-        this.options.ambiguousErrorMessages
+        this.server.options.ambiguousErrorMessages
           ? this.options.errors.invalidCredentials
           : this.options.errors.userNotFound
       );

--- a/packages/password/src/errors.ts
+++ b/packages/password/src/errors.ts
@@ -10,6 +10,7 @@ export const errors: ErrorMessages = {
   invalidPassword: 'Invalid password',
   invalidNewPassword: 'Invalid new password',
   invalidToken: 'Invalid token',
+  invalidCredentials: 'Invalid credentials',
   verifyEmailLinkExpired: 'Verify email link expired',
   verifyEmailLinkUnknownAddress: 'Verify email link is for unknown address',
   resetPasswordLinkExpired: 'Reset password link expired',

--- a/packages/password/src/types/error-messages.ts
+++ b/packages/password/src/types/error-messages.ts
@@ -32,6 +32,10 @@ export interface ErrorMessages {
    */
   invalidNewPassword: string;
   /**
+   * Default to 'Invalid credentials'
+   */
+  invalidCredentials: string;
+  /**
    * Default to 'Invalid token'
    */
   invalidToken: string;

--- a/packages/rest-express/__tests__/endpoints/password/register.ts
+++ b/packages/rest-express/__tests__/endpoints/password/register.ts
@@ -40,7 +40,7 @@ describe('registerPassword', () => {
     expect(accountsServer.getServices().password.createUser).toBeCalledWith({
       username: 'toto',
     });
-    expect(res.json).toBeCalledWith({ userId: '1' });
+    expect(res.json).toBeCalledWith('1');
     expect(res.status).not.toBeCalled();
   });
 
@@ -74,7 +74,7 @@ describe('registerPassword', () => {
     expect(accountsServer.getServices().password.createUser).toBeCalledWith({
       username: 'toto',
     });
-    expect(res.json).toBeCalledWith({ userId: null });
+    expect(res.json).toBeCalledWith(null);
     expect(res.status).not.toBeCalled();
   });
 

--- a/packages/rest-express/src/endpoints/password/register.ts
+++ b/packages/rest-express/src/endpoints/password/register.ts
@@ -9,7 +9,7 @@ export const registerPassword = (accountsServer: AccountsServer) => async (
   try {
     const password: any = accountsServer.getServices().password;
     const userId = await password.createUser(req.body.user);
-    res.json({ userId: accountsServer.options.ambiguousErrorMessages ? null : userId });
+    res.json(accountsServer.options.ambiguousErrorMessages ? null : userId);
   } catch (err) {
     sendError(res, err);
   }

--- a/packages/rest-express/src/endpoints/password/register.ts
+++ b/packages/rest-express/src/endpoints/password/register.ts
@@ -9,7 +9,7 @@ export const registerPassword = (accountsServer: AccountsServer) => async (
   try {
     const password: any = accountsServer.getServices().password;
     const userId = await password.createUser(req.body.user);
-    res.json({ userId });
+    res.json({ userId: accountsServer.options.ambiguousErrorMessages ? null : userId });
   } catch (err) {
     sendError(res, err);
   }

--- a/packages/server/__tests__/account-server.ts
+++ b/packages/server/__tests__/account-server.ts
@@ -1056,6 +1056,7 @@ describe('AccountsServer', () => {
             findUserByUsername: () => Promise.resolve(null),
           } as any,
           tokenSecret: 'secret1',
+          ambiguousErrorMessages: false,
         },
         {}
       );

--- a/packages/server/src/accounts-server.ts
+++ b/packages/server/src/accounts-server.ts
@@ -23,6 +23,7 @@ import { JwtData } from './types/jwt-data';
 import { EmailTemplateType } from './types/email-template-type';
 
 const defaultOptions = {
+  ambiguousErrorMessages: true,
   tokenSecret: 'secret',
   tokenConfigs: {
     accessToken: {

--- a/packages/server/src/accounts-server.ts
+++ b/packages/server/src/accounts-server.ts
@@ -208,6 +208,9 @@ Please change it with a strong random token.`);
       }
 
       if (!impersonatedUser) {
+        if (this.options.ambiguousErrorMessages) {
+          return { authorized: false };
+        }
         throw new Error(`Impersonated user not found`);
       }
 

--- a/packages/server/src/types/accounts-server-options.ts
+++ b/packages/server/src/types/accounts-server-options.ts
@@ -7,6 +7,10 @@ import { PrepareMailFunction } from './prepare-mail-function';
 import { SendMailType } from './send-mail-type';
 
 export interface AccountsServerOptions {
+  /**
+   * Return ambiguous error messages from login failures to prevent user enumeration. Defaults to true.
+   */
+  ambiguousErrorMessages?: boolean;
   db?: DatabaseInterface;
   tokenSecret: string;
   tokenConfigs?: {


### PR DESCRIPTION
Close #337 

- **Breaking change:** new server options `ambiguousErrorMessages` that default to true.
When this option is true all the messages that allow user enumeration are hidden:
- when trying to login with wrong credentials before was throwing with `User not found`, now `Invalid credentials`
- when trying to send an email to reset the password if the user email is not found fail silently
- when trying to send an email to verify the password if the user email is not found fail silently
- when trying to create a new user, we return null to the client instead of the user id (the transports are intercepting the id and return null) if user already exist the function will fail silently
- when trying to impersonate, we return `{ authorized: false }`
- **Breaking change:** the register route of the `rest-express` package now return the userId as a string instead of `{ userId: ''}`
