### PR TITLE
[doc](boost-usage): Replace AccountsServer with AccountsBoost

### DIFF
--- a/packages/boost/README.md
+++ b/packages/boost/README.md
@@ -12,7 +12,7 @@ yarn add @accounts/boost
 ## Usage
 
 ```js
-import { AccountsBoost  } from '@accounts/boost';
+import { AccountsBoost } from '@accounts/boost';
 
 const accountsBoost = new AccountsBoost();
 

--- a/packages/boost/README.md
+++ b/packages/boost/README.md
@@ -12,9 +12,9 @@ yarn add @accounts/boost
 ## Usage
 
 ```js
-import { AccountsServer } from '@accounts/boost';
+import { AccountsBoost  } from '@accounts/boost';
 
-const accountsServer = new AccountsServer();
+const accountsBoost = new AccountsBoost();
 
-accountsServer.listen();
+accountsBoost.listen();
 ```


### PR DESCRIPTION
Replace AccountsServer with AccountsBoost in usage doc for boost README

contributes to accounts-js/accounts#368

as discussed here https://github.com/accounts-js/accounts/issues/368#issuecomment-443282080