### PR TITLE
Use a function for AccountsClient in apollo-link

### DIFF
--- a/packages/apollo-link-accounts/src/index.ts
+++ b/packages/apollo-link-accounts/src/index.ts
@@ -1,15 +1,14 @@
 import { setContext } from 'apollo-link-context';
 import { ApolloLink } from 'apollo-link';
-import { AccountsClient } from '@accounts/client';
 
-export const accountsLink = (accountsClient: AccountsClient): ApolloLink => {
+export const accountsLink = ({ headerName = 'accounts-access-token' }): ApolloLink => {
   return setContext(async (_, { headers: headersWithoutTokens }) => {
-    const tokens = await accountsClient.refreshSession();
-
     const headers = { ...headersWithoutTokens };
 
-    if (tokens) {
-      headers['accounts-access-token'] = tokens.accessToken;
+    const token = localStorage.getItem('accounts:accessToken');
+
+    if (token) {
+      headers[headerName] = token;
     }
 
     return {

--- a/packages/apollo-link-accounts/src/index.ts
+++ b/packages/apollo-link-accounts/src/index.ts
@@ -1,14 +1,18 @@
 import { setContext } from 'apollo-link-context';
 import { ApolloLink } from 'apollo-link';
+import { AccountsClient } from '@accounts/client';
 
-export const accountsLink = ({ headerName = 'accounts-access-token' }): ApolloLink => {
+type AccountsClientFactory = () => AccountsClient | Promise<AccountsClient>;
+
+export const accountsLink = (accountsClientFactory: AccountsClientFactory): ApolloLink => {
   return setContext(async (_, { headers: headersWithoutTokens }) => {
+    const accountsClient = await accountsClientFactory();
+    const tokens = await accountsClient.refreshSession();
+
     const headers = { ...headersWithoutTokens };
 
-    const token = localStorage.getItem('accounts:accessToken');
-
-    if (token) {
-      headers[headerName] = token;
+    if (tokens) {
+      headers['accounts-access-token'] = tokens.accessToken;
     }
 
     return {


### PR DESCRIPTION
Fixes #470 
Using a function will make available to handle circular imports;
```ts
accountsLink(() => accountsClient)
```
