### PR TITLE
Remove ambiguousErrorMessages from `createUser`

### DIFF
--- a/packages/e2e/__tests__/password.ts
+++ b/packages/e2e/__tests__/password.ts
@@ -18,7 +18,7 @@ Object.keys(servers).forEach(key => {
           email: user.email,
           password: user.password,
         });
-        expect(userId).toBeNull();
+        expect(userId).toBeTruthy();
       });
     });
 

--- a/packages/graphql-api/src/modules/accounts-password/resolvers/mutation.ts
+++ b/packages/graphql-api/src/modules/accounts-password/resolvers/mutation.ts
@@ -16,7 +16,7 @@ export const Mutation: MutationResolvers<ModuleContext<AccountsModuleContext>> =
   },
   createUser: async (_, { user }, { injector }) => {
     const userId = await injector.get(AccountsPassword).createUser(user as PasswordCreateUserType);
-    return injector.get(AccountsServer).options.ambiguousErrorMessages ? null : userId;
+    return userId;
   },
   twoFactorSet: async (_, { code, secret }, { user, injector }) => {
     // Make sure user is logged in

--- a/packages/rest-express/src/endpoints/password/register.ts
+++ b/packages/rest-express/src/endpoints/password/register.ts
@@ -1,5 +1,6 @@
-import * as express from 'express';
 import { AccountsServer } from '@accounts/server';
+import * as express from 'express';
+
 import { sendError } from '../../utils/send-error';
 
 export const registerPassword = (accountsServer: AccountsServer) => async (
@@ -9,7 +10,7 @@ export const registerPassword = (accountsServer: AccountsServer) => async (
   try {
     const password: any = accountsServer.getServices().password;
     const userId = await password.createUser(req.body.user);
-    res.json(accountsServer.options.ambiguousErrorMessages ? null : userId);
+    res.json({ userId });
   } catch (err) {
     sendError(res, err);
   }


### PR DESCRIPTION
The created user's id should always be returned from `createUser` even if ambiguousErrorMessages is set to true.

**todo**

- [ ] update tests