### PR TITLE
fix: ignore context when no req available

### DIFF
--- a/packages/graphql-api/src/utils/context-builder.ts
+++ b/packages/graphql-api/src/utils/context-builder.ts
@@ -9,6 +9,7 @@ export const context = (moduleName: string) => async (
   _: any,
   { injector }: ModuleSessionInfo
 ) => {
+  if (!req) { return; }
   const config: AccountsModuleConfig = injector.get(ModuleConfig(moduleName));
   const headerName = config.headerName || 'accounts-access-token';
   const authToken = (req.headers[headerName] || req.headers[headerName.toLowerCase()]) as string;


### PR DESCRIPTION
If you have other graphql-modules with subscriptions (through websocket), there will be no `req` object and it will fail unrelated subscriptions because of this.