### PR TITLE
[password] Send user an email when their password has been changed

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "printWidth": 100
   },
   "resolutions": {
-    "@types/node": "10.12.21"
+    "@types/node": "10.12.24"
   },
   "renovate": {
     "extends": [

--- a/packages/e2e/__tests__/servers/server-graphql.ts
+++ b/packages/e2e/__tests__/servers/server-graphql.ts
@@ -59,6 +59,11 @@ export class ServerGraphqlTest implements ServerTestInterface {
             subject: () => 'Set your password',
             text: (user: User, url: string) => convertUrlToToken(url),
           },
+          passwordChanged: {
+            subject: () => 'Your password has been changed',
+            text: () => `Your account password has been successfully changed`,
+            html: () => `Your account password has been successfully changed.`,
+          },
         },
         sendMail: async mail => {
           this.emails.push(mail);

--- a/packages/e2e/__tests__/servers/server-rest.ts
+++ b/packages/e2e/__tests__/servers/server-rest.ts
@@ -63,6 +63,11 @@ export class ServerRestTest implements ServerTestInterface {
             subject: () => 'Set your password',
             text: (user: User, url: string) => convertUrlToToken(url),
           },
+          passwordChanged: {
+            subject: () => 'Your password has been changed',
+            text: () => `Your account password has been successfully changed`,
+            html: () => `Your account password has been successfully changed.`,
+          },
         },
         sendMail: async mail => {
           this.emails.push(mail);

--- a/packages/password/__tests__/accounts-password.ts
+++ b/packages/password/__tests__/accounts-password.ts
@@ -301,6 +301,15 @@ describe('AccountsPassword', () => {
         invalidateAllSessions,
         verifyEmail,
       } as any);
+      const prepareMail = jest.fn(() => Promise.resolve());
+      const sanitizeUser = jest.fn(() => Promise.resolve());
+      const sendMail = jest.fn(() => Promise.resolve());
+      password.server = {
+        prepareMail,
+        options: { sendMail },
+        sanitizeUser,
+      } as any;
+      set(password.server, 'options.emailTemplates', {});
       await password.resetPassword(token, newPassword, connectionInfo);
       expect(setResetPassword.mock.calls.length).toBe(1);
       expect(verifyEmail.mock.calls.length).toBe(1);
@@ -317,7 +326,17 @@ describe('AccountsPassword', () => {
         setResetPassword,
         invalidateAllSessions,
       } as any);
-      password.server = { isTokenExpired, loginWithUser: jest.fn() } as any;
+      const prepareMail = jest.fn(() => Promise.resolve());
+      const sanitizeUser = jest.fn(() => Promise.resolve());
+      const sendMail = jest.fn(() => Promise.resolve());
+      password.server = {
+        isTokenExpired,
+        loginWithUser: jest.fn(),
+        prepareMail,
+        options: { sendMail },
+        sanitizeUser,
+      } as any;
+      set(password.server, 'options.emailTemplates', {});
       const loginResult = await password.resetPassword(token, newPassword, connectionInfo);
       expect(loginResult).toBeNull();
       expect(setResetPassword.mock.calls.length).toBe(1);
@@ -346,7 +365,17 @@ describe('AccountsPassword', () => {
         setResetPassword,
         invalidateAllSessions,
       } as any);
-      tmpAccountsPassword.server = { isTokenExpired, loginWithUser } as any;
+      const prepareMail = jest.fn(() => Promise.resolve());
+      const sanitizeUser = jest.fn(() => Promise.resolve());
+      const sendMail = jest.fn(() => Promise.resolve());
+      tmpAccountsPassword.server = {
+        isTokenExpired,
+        loginWithUser,
+        prepareMail,
+        options: { sendMail },
+        sanitizeUser,
+      } as any;
+      set(tmpAccountsPassword.server, 'options.emailTemplates', {});
       const loginResult = await tmpAccountsPassword.resetPassword(
         token,
         newPassword,

--- a/packages/password/__tests__/accounts-password.ts
+++ b/packages/password/__tests__/accounts-password.ts
@@ -371,10 +371,24 @@ describe('AccountsPassword', () => {
   });
 
   describe('changePassword', () => {
+    const validUser = {
+      emails: [{ address: 'john.doe@gmail.com', verified: true }],
+    };
+
     it('call passwordAuthenticator and this.db.setPassword', async () => {
       const userId = 'id';
       const setPassword = jest.fn(() => Promise.resolve('user'));
-      password.setStore({ setPassword } as any);
+      const findUserById = jest.fn(() => Promise.resolve(validUser));
+      password.setStore({ setPassword, findUserById } as any);
+      const prepareMail = jest.fn(() => Promise.resolve());
+      const sanitizeUser = jest.fn(() => Promise.resolve());
+      const sendMail = jest.fn(() => Promise.resolve());
+      password.server = {
+        prepareMail,
+        options: { sendMail },
+        sanitizeUser,
+      } as any;
+      set(password.server, 'options.emailTemplates', {});
       const passwordAuthenticator = jest
         .spyOn(password, 'passwordAuthenticator' as any)
         .mockImplementation(() => Promise.resolve({}));
@@ -383,6 +397,8 @@ describe('AccountsPassword', () => {
       expect(passwordAuthenticator.mock.calls[0][1]).toEqual('old-password');
       expect(setPassword.mock.calls[0][0]).toEqual(userId);
       expect(setPassword.mock.calls[0][1]).toBeTruthy();
+      expect(prepareMail.mock.calls[0].length).toBe(6);
+      expect(sendMail.mock.calls[0].length).toBe(1);
       (password as any).passwordAuthenticator.mockRestore();
     });
   });

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -247,20 +247,22 @@ export default class AccountsPassword implements AuthenticationService {
     // Changing the password should invalidate existing sessions
     await this.db.invalidateAllSessions(user.id);
 
-    const address = user.emails && user.emails[0].address;
-    if (!address) {
-      throw new Error(this.options.errors.noEmailSet);
-    }
+    if (this.options.notifyUserAfterPasswordChanged) {
+      const address = user.emails && user.emails[0].address;
+      if (!address) {
+        throw new Error(this.options.errors.noEmailSet);
+      }
 
-    const passwordChangedtMail = this.server.prepareMail(
-      address,
-      '',
-      this.server.sanitizeUser(user),
-      '',
-      this.server.options.emailTemplates.passwordChanged,
-      this.server.options.emailTemplates.from
-    );
-    await this.server.options.sendMail(passwordChangedtMail);
+      const passwordChangedMail = this.server.prepareMail(
+        address,
+        '',
+        this.server.sanitizeUser(user),
+        '',
+        this.server.options.emailTemplates.passwordChanged,
+        this.server.options.emailTemplates.from
+      );
+      await this.server.options.sendMail(passwordChangedMail);
+    }
 
     if (this.options.returnTokensAfterResetPassword) {
       return this.server.loginWithUser(user, infos);
@@ -293,28 +295,30 @@ export default class AccountsPassword implements AuthenticationService {
   ): Promise<void> {
     await this.passwordAuthenticator({ id: userId }, oldPassword);
 
-    const user = await this.db.findUserById(userId);
-    if (!user) {
-      throw new Error(this.options.errors.userNotFound);
-    }
-
     const password = await bcryptPassword(newPassword);
     await this.db.setPassword(userId, password);
 
-    const address = user.emails && user.emails[0].address;
-    if (!address) {
-      throw new Error(this.options.errors.noEmailSet);
-    }
+    if (this.options.notifyUserAfterPasswordChanged) {
+      const user = await this.db.findUserById(userId);
+      if (!user) {
+        throw new Error(this.options.errors.userNotFound);
+      }
 
-    const passwordChangedtMail = this.server.prepareMail(
-      address,
-      '',
-      this.server.sanitizeUser(user),
-      '',
-      this.server.options.emailTemplates.passwordChanged,
-      this.server.options.emailTemplates.from
-    );
-    await this.server.options.sendMail(passwordChangedtMail);
+      const address = user.emails && user.emails[0].address;
+      if (!address) {
+        throw new Error(this.options.errors.noEmailSet);
+      }
+
+      const passwordChangedMail = this.server.prepareMail(
+        address,
+        '',
+        this.server.sanitizeUser(user),
+        '',
+        this.server.options.emailTemplates.passwordChanged,
+        this.server.options.emailTemplates.from
+      );
+      await this.server.options.sendMail(passwordChangedMail);
+    }
   }
 
   /**

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -43,6 +43,12 @@ export interface AccountsPasswordOptions {
    * Accounts password module errors
    */
   errors?: ErrorMessages;
+  /**
+   * Notify a user after his password has been changed.
+   * This email is sent when the user reset his password and when he change it.
+   * Default to true.
+   */
+  notifyUserAfterPasswordChanged?: boolean;
   returnTokensAfterResetPassword?: boolean;
   validateNewUser?: (
     user: PasswordCreateUserType
@@ -60,6 +66,7 @@ const defaultOptions = {
   passwordResetTokenExpiration: 259200000,
   // 30 days - 30 * 24 * 60 * 60 * 1000
   passwordEnrollTokenExpiration: 2592000000,
+  notifyUserAfterPasswordChanged: true,
   returnTokensAfterResetPassword: false,
   validateEmail(email?: string): boolean {
     return !isEmpty(trim(email)) && isEmail(email);
@@ -240,11 +247,25 @@ export default class AccountsPassword implements AuthenticationService {
     // Changing the password should invalidate existing sessions
     await this.db.invalidateAllSessions(user.id);
 
+    const address = user.emails && user.emails[0].address;
+    if (!address) {
+      throw new Error(this.options.errors.noEmailSet);
+    }
+
+    const passwordChangedtMail = this.server.prepareMail(
+      address,
+      '',
+      this.server.sanitizeUser(user),
+      '',
+      this.server.options.emailTemplates.passwordChanged,
+      this.server.options.emailTemplates.from
+    );
+    await this.server.options.sendMail(passwordChangedtMail);
+
     if (this.options.returnTokensAfterResetPassword) {
       return this.server.loginWithUser(user, infos);
-    } else {
-      return null;
     }
+    return null;
   }
 
   /**
@@ -271,8 +292,29 @@ export default class AccountsPassword implements AuthenticationService {
     newPassword: string
   ): Promise<void> {
     await this.passwordAuthenticator({ id: userId }, oldPassword);
+
+    const user = await this.db.findUserById(userId);
+    if (!user) {
+      throw new Error(this.options.errors.userNotFound);
+    }
+
     const password = await bcryptPassword(newPassword);
-    return this.db.setPassword(userId, password);
+    await this.db.setPassword(userId, password);
+
+    const address = user.emails && user.emails[0].address;
+    if (!address) {
+      throw new Error(this.options.errors.noEmailSet);
+    }
+
+    const passwordChangedtMail = this.server.prepareMail(
+      address,
+      '',
+      this.server.sanitizeUser(user),
+      '',
+      this.server.options.emailTemplates.passwordChanged,
+      this.server.options.emailTemplates.from
+    );
+    await this.server.options.sendMail(passwordChangedtMail);
   }
 
   /**

--- a/packages/password/src/errors.ts
+++ b/packages/password/src/errors.ts
@@ -3,6 +3,7 @@ import { ErrorMessages } from './types';
 export const errors: ErrorMessages = {
   userNotFound: 'User not found',
   noPasswordSet: 'User has no password set',
+  noEmailSet: 'User has no email set',
   incorrectPassword: 'Incorrect password',
   unrecognizedOptionsForLogin: 'Unrecognized options for login request',
   matchFailed: 'Match failed',

--- a/packages/password/src/types/error-messages.ts
+++ b/packages/password/src/types/error-messages.ts
@@ -8,6 +8,10 @@ export interface ErrorMessages {
    */
   noPasswordSet: string;
   /**
+   * Default to 'User has no email set'
+   */
+  noEmailSet: string;
+  /**
    * Default to 'Incorrect password'
    */
   incorrectPassword: string;

--- a/packages/server/__tests__/utils/__snapshots__/email.ts.snap
+++ b/packages/server/__tests__/utils/__snapshots__/email.ts.snap
@@ -6,14 +6,20 @@ exports[`email emailTemplates should return default html 2`] = `"To reset your p
 
 exports[`email emailTemplates should return default html 3`] = `"To set your password please <a href=\\"url\\">click here</a>."`;
 
+exports[`email emailTemplates should return default html 4`] = `"Your account password has been successfully changed."`;
+
 exports[`email emailTemplates should return default subject 1`] = `"Verify your account email"`;
 
 exports[`email emailTemplates should return default subject 2`] = `"Reset your password"`;
 
 exports[`email emailTemplates should return default subject 3`] = `"Set your password"`;
 
+exports[`email emailTemplates should return default subject 4`] = `"Your password has been changed"`;
+
 exports[`email emailTemplates should return default text 1`] = `"To verify your account email please click on this link: url"`;
 
 exports[`email emailTemplates should return default text 2`] = `"To reset your password please click on this link: url"`;
 
 exports[`email emailTemplates should return default text 3`] = `"To set your password please click on this link: url"`;
+
+exports[`email emailTemplates should return default text 4`] = `"Your account password has been successfully changed"`;

--- a/packages/server/__tests__/utils/email.ts
+++ b/packages/server/__tests__/utils/email.ts
@@ -6,6 +6,7 @@ describe('email', () => {
       expect(emailTemplates.verifyEmail.subject()).toMatchSnapshot();
       expect(emailTemplates.resetPassword.subject()).toMatchSnapshot();
       expect(emailTemplates.enrollAccount.subject()).toMatchSnapshot();
+      expect(emailTemplates.passwordChanged.subject()).toMatchSnapshot();
     });
 
     it('should return default text', () => {
@@ -14,6 +15,7 @@ describe('email', () => {
       expect(emailTemplates.verifyEmail.text(user, url)).toMatchSnapshot();
       expect(emailTemplates.resetPassword.text(user, url)).toMatchSnapshot();
       expect(emailTemplates.enrollAccount.text(user, url)).toMatchSnapshot();
+      expect(emailTemplates.passwordChanged.text(user, url)).toMatchSnapshot();
     });
 
     it('should return default html', () => {
@@ -22,6 +24,7 @@ describe('email', () => {
       expect(emailTemplates.verifyEmail.html!(user, url)).toMatchSnapshot();
       expect(emailTemplates.resetPassword.html!(user, url)).toMatchSnapshot();
       expect(emailTemplates.enrollAccount.html!(user, url)).toMatchSnapshot();
+      expect(emailTemplates.passwordChanged.html!(user, url)).toMatchSnapshot();
     });
   });
 });

--- a/packages/server/src/types/email-templates-type.ts
+++ b/packages/server/src/types/email-templates-type.ts
@@ -5,4 +5,5 @@ export interface EmailTemplatesType {
   verifyEmail: EmailTemplateType;
   resetPassword: EmailTemplateType;
   enrollAccount: EmailTemplateType;
+  passwordChanged: EmailTemplateType;
 }

--- a/packages/server/src/utils/email.ts
+++ b/packages/server/src/utils/email.ts
@@ -25,6 +25,12 @@ export const emailTemplates: EmailTemplatesType = {
     html: (user: User, url: string) =>
       `To set your password please <a href="${url}">click here</a>.`,
   },
+
+  passwordChanged: {
+    subject: () => 'Your password has been changed',
+    text: () => `Your account password has been successfully changed`,
+    html: () => `Your account password has been successfully changed.`,
+  },
 };
 
 export type SendMailType = (mail: object) => Promise<void>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -448,10 +448,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@10.12.21", "@types/node@10.12.24", "@types/node@^10.1.0":
-  version "10.12.21"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.21.tgz#7e8a0c34cf29f4e17a36e9bd0ea72d45ba03908e"
-  integrity sha512-CBgLNk4o3XMnqMc0rhb6lc77IwShMEglz05deDcn2lQxyXEZivfwgYJu7SMha9V5XcrP6qZuevTHV/QrN2vjKQ==
+"@types/node@*", "@types/node@10.12.24", "@types/node@^10.1.0":
+  version "10.12.24"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.24.tgz#b13564af612a22a20b5d95ca40f1bffb3af315cf"
+  integrity sha512-GWWbvt+z9G5otRBW8rssOFgRY87J9N/qbhqfjMZ+gUuL6zoL+Hm6gP/8qQBG4jjimqdaNLCehcVapZ/Fs2WjCQ==
 
 "@types/oauth@0.9.1":
   version "0.9.1"


### PR DESCRIPTION
Close #51 

**Breaking change** Enabled by default, if you don't want to send the email set the accounts-password `notifyUserAfterPasswordChanged` option to false.