### PR TITLE
Typeorm should not have pg in its dependencies

### DIFF
--- a/packages/database-typeorm/package.json
+++ b/packages/database-typeorm/package.json
@@ -37,7 +37,6 @@
   "dependencies": {
     "@accounts/types": "^0.13.0",
     "lodash": "^4.17.11",
-    "pg": "^7.8.0",
     "reflect-metadata": "^0.1.13",
     "tslib": "1.9.3",
     "typeorm": "^0.2.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6435,7 +6435,7 @@ pg-types@~2.0.0:
     postgres-date "~1.0.0"
     postgres-interval "^1.1.0"
 
-pg@^7.8.0:
+pg@7.8.0:
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/pg/-/pg-7.8.0.tgz#541c25b3323d85f67ce7d4501a77470976868ce9"
   integrity sha512-yS3C9YD+ft0H7G47uU0eKajgTieggCXdA+Fxhm5G+wionY6kPBa8BEVDwPLMxQvkRkv3/LXiFEqjZm9gfxdW+g==


### PR DESCRIPTION
Since it can be used with mysql etc we let the user choose