### PR TITLE
[@accounts/graphql-client] Remove the try catch around the mutate and query functions to forward the native graphql error

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "printWidth": 100
   },
   "resolutions": {
-    "@types/node": "10.12.24"
+    "@types/node": "10.14.4"
   },
   "renovate": {
     "extends": [

--- a/packages/graphql-client/src/graphql-client.ts
+++ b/packages/graphql-client/src/graphql-client.ts
@@ -159,39 +159,31 @@ export default class GraphQLClient implements TransportInterface {
         ? await this.client.getTokens()
         : await this.client.refreshSession();
 
-    try {
-      const { data } = await this.options.graphQLClient.mutate({
-        mutation,
-        variables,
-        context: {
-          headers: {
-            Authorization: tokens ? 'Bearer ' + tokens.accessToken : '',
-          },
+    const { data } = await this.options.graphQLClient.mutate({
+      mutation,
+      variables,
+      context: {
+        headers: {
+          Authorization: tokens ? 'Bearer ' + tokens.accessToken : '',
         },
-      });
-      return data[resultField];
-    } catch (e) {
-      throw new Error(e.message);
-    }
+      },
+    });
+    return data[resultField];
   }
 
   private async query(query: any, resultField: any, variables: any = {}) {
     const tokens = await this.client.refreshSession();
 
-    try {
-      const { data } = await this.options.graphQLClient.query({
-        query,
-        variables,
-        fetchPolicy: 'network-only',
-        context: {
-          headers: {
-            Authorization: tokens ? 'Bearer ' + tokens.accessToken : '',
-          },
+    const { data } = await this.options.graphQLClient.query({
+      query,
+      variables,
+      fetchPolicy: 'network-only',
+      context: {
+        headers: {
+          Authorization: tokens ? 'Bearer ' + tokens.accessToken : '',
         },
-      });
-      return data[resultField];
-    } catch (e) {
-      throw new Error(e.message);
-    }
+      },
+    });
+    return data[resultField];
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -456,10 +456,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@10.12.24", "@types/node@10.14.4", "@types/node@^10.1.0":
-  version "10.12.24"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.24.tgz#b13564af612a22a20b5d95ca40f1bffb3af315cf"
-  integrity sha512-GWWbvt+z9G5otRBW8rssOFgRY87J9N/qbhqfjMZ+gUuL6zoL+Hm6gP/8qQBG4jjimqdaNLCehcVapZ/Fs2WjCQ==
+"@types/node@*", "@types/node@10.14.4", "@types/node@^10.1.0":
+  version "10.14.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.4.tgz#1c586b991457cbb58fef51bc4e0cfcfa347714b5"
+  integrity sha512-DT25xX/YgyPKiHFOpNuANIQIVvYEwCWXgK2jYYwqgaMrYE6+tq+DtmMwlD3drl6DJbUwtlIDnn0d7tIn/EbXBg==
 
 "@types/oauth@0.9.1":
   version "0.9.1"


### PR DESCRIPTION
The problem we have currently is that we try catch around the mutate and query functions so we do not forward the graphql error object. The limitation I found is that I cannot access the `graphqlErrors` property when the function is throwing.