### PR TITLE
Adding TypeORM to docs

### DIFF
--- a/docs/databases/typeorm.md
+++ b/docs/databases/typeorm.md
@@ -75,7 +75,7 @@ export const connect = (url = 'postgres://localhost:5432') => {
 ## Example
 
 You can find an example using the database-typeeorm package with a PostgreSQL database in the examples folder
-[graphql-server-typeorm-postgres](https://github.com/accounts-js/accounts/tree/master/examples/graphql-server-typeorm-postgres) 
+[graphql-server-typeorm-postgres](https://github.com/accounts-js/accounts/tree/master/examples/graphql-server-typeorm-postgres)
 
 ## Notice
 

--- a/docs/databases/typeorm.md
+++ b/docs/databases/typeorm.md
@@ -1,0 +1,83 @@
+---
+id: typeorm
+title: Typeorm
+sidebar_label: Typeorm
+---
+
+TypeORM data store for accounts-js
+
+[Github](https://github.com/accounts-js/accounts/tree/master/packages/database-mongo) |
+[npm](https://www.npmjs.com/package/@accounts/typeorm)
+
+## Install
+
+```javascript
+yarn add @accounts/typeorm typeorm pg
+```
+
+## Usage
+
+```typescript
+import AccountsServer from '@accounts/server';
+import typeorm from '@accounts/typeorm';
+import { createConnection } from 'typeorm';
+export const createAccounts = async () => {
+  const connection = await connect(process.env.DATABASE_URL);
+  // Like, fix this man!
+  const tokenSecret = 'BAD SECRET';
+  const db = new AccountsTypeorm({ connection, cache: 1000 });
+  const password = new AccountsPassword();
+  const accountsServer = new AccountsServer(
+    {
+      db,
+      tokenSecret,
+      siteUrl: 'http://localhost:3000',
+    },
+    { password }
+  );
+  // Creates resolvers, type definitions, and schema directives used by accounts-js
+  const accountsGraphQL = AccountsModule.forRoot({
+    accountsServer,
+  });
+  };
+  const schema = makeExecutableSchema({
+    typeDefs: mergeTypeDefs[accountsGraphQL.typeDefs],
+    resolvers: [accountsGraphQL.resolvers],
+    schemaDirectives: {
+      ...accountsGraphQL.schemaDirectives,
+    },
+  });
+
+  // Create the Apollo Server that takes a schema and configures internal stuff
+  const server = new ApolloServer({
+    schema,
+    context: accountsGraphQL.context,
+  });
+
+  server.listen(4000).then(({ url }) => {
+    // tslint:disable-next-line:no-console
+    console.log(`🚀  Server ready at ${url}`);
+  });
+};
+createAccounts();
+// Edit this line with your postgres url
+export const connect = (url = 'postgres://localhost:5432') => {
+  return createConnection({
+    type: 'postgres',
+    url,
+    entities: [...require('@accounts/typeorm').entities],
+    synchronize: true,
+  }).then(connection => {
+    return connection;
+  });
+```
+
+## Example
+
+You can find an example using the database-typeeorm package with a PostgreSQL database in the examples folder
+[graphql-server-typeorm-postgres](https://github.com/accounts-js/accounts/tree/master/examples/graphql-server-typeorm-postgres) 
+
+## Notice
+
+It is our long-term goal for typeorm package to be database agnostic and support all database types it does by default.
+For now it only works and has been tested with PostgreSQL, feel free to explore other typeorm-integrations.

--- a/docs/databases/typeorm.md
+++ b/docs/databases/typeorm.md
@@ -1,7 +1,7 @@
 ---
 id: typeorm
-title: Typeorm
-sidebar_label: Typeorm
+title: TypeORM
+sidebar_label: TypeORM
 ---
 
 TypeORM data store for accounts-js

--- a/docs/databases/typeorm.md
+++ b/docs/databases/typeorm.md
@@ -9,10 +9,8 @@ TypeORM data store for accounts-js
 [Github](https://github.com/accounts-js/accounts/tree/master/packages/database-mongo) |
 [npm](https://www.npmjs.com/package/@accounts/typeorm)
 
-## > Notice
-
-It is our long-term goal for typeorm package to be database agnostic and support all database types it does by default.
-For now it only works and has been tested with PostgreSQL, feel free to explore other typeorm-integrations.
+> It is our long-term goal for typeorm package to be database agnostic and support all database types it does by default.
+> For now it only works and has been tested with PostgreSQL, feel free to explore other typeorm-integrations.
 
 ## Install
 

--- a/docs/databases/typeorm.md
+++ b/docs/databases/typeorm.md
@@ -9,6 +9,11 @@ TypeORM data store for accounts-js
 [Github](https://github.com/accounts-js/accounts/tree/master/packages/database-mongo) |
 [npm](https://www.npmjs.com/package/@accounts/typeorm)
 
+## > Notice
+
+It is our long-term goal for typeorm package to be database agnostic and support all database types it does by default.
+For now it only works and has been tested with PostgreSQL, feel free to explore other typeorm-integrations.
+
 ## Install
 
 ```javascript
@@ -21,6 +26,7 @@ yarn add @accounts/typeorm typeorm pg
 import AccountsServer from '@accounts/server';
 import typeorm from '@accounts/typeorm';
 import { createConnection } from 'typeorm';
+
 export const createAccounts = async () => {
   const connection = await connect(process.env.DATABASE_URL);
   // Like, fix this man!
@@ -76,8 +82,3 @@ export const connect = (url = 'postgres://localhost:5432') => {
 
 You can find an example using the database-typeeorm package with a PostgreSQL database in the examples folder
 [graphql-server-typeorm-postgres](https://github.com/accounts-js/accounts/tree/master/examples/graphql-server-typeorm-postgres)
-
-## Notice
-
-It is our long-term goal for typeorm package to be database agnostic and support all database types it does by default.
-For now it only works and has been tested with PostgreSQL, feel free to explore other typeorm-integrations.

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,6 +15,6 @@ GraphQL Server + GraphQL Client example:
 Other examples:
 
 - Accounts Boost [accounts-boost](./accounts-boost)
-- Typeorm + PostgreSQL example  [graphql-server-typeorm-postgres](./graphql-server-typeorm-postgres)
+- Typeorm + PostgreSQL example [graphql-server-typeorm-postgres](./graphql-server-typeorm-postgres)
 
 Please go to corresponding packages and see its README.

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,4 +12,9 @@ GraphQL Server + GraphQL Client example:
 - Server: [graphql-server-typescript](./graphql-server-typescript)
 - Client: [react-graphql-typescript](./react-graphql-typescript)
 
+Other examples:
+
+- Accounts Boost [accounts-boost](./accounts-boost)
+- Typeorm + PostgreSQL example  [graphql-server-typeorm-postgres](./graphql-server-typeorm-postgres)
+
 Please go to corresponding packages and see its README.

--- a/examples/accounts-boost/README.md
+++ b/examples/accounts-boost/README.md
@@ -1,6 +1,6 @@
 # accounts-boost examples
 
-Includes two two examples of using `@accounts/boost`.
+Includes two examples of using `@accounts/boost`.
 
 `yarn start:mono` - Starts a GraphQL server which consumes the `@accounts/boost` typeDefs and resolvers when building your app's schema.
 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -22,9 +22,19 @@
     ]
   },
   "docs": {
-    "Getting started": ["getting-started", "email"],
-    "Transports": ["transports/graphql", "transports/rest"],
-    "Databases": ["databases/mongo", "databases/redis"],
+    "Getting started": [
+      "getting-started",
+      "email"
+    ],
+    "Transports": [
+      "transports/graphql",
+      "transports/rest"
+    ],
+    "Databases": [
+      "databases/mongo",
+      "databases/redis",
+      "databases/typeorm"
+    ],
     "Strategies": [
       "strategies/password",
       "strategies/facebook",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -22,19 +22,9 @@
     ]
   },
   "docs": {
-    "Getting started": [
-      "getting-started",
-      "email"
-    ],
-    "Transports": [
-      "transports/graphql",
-      "transports/rest"
-    ],
-    "Databases": [
-      "databases/mongo",
-      "databases/redis",
-      "databases/typeorm"
-    ],
+    "Getting started": ["getting-started", "email"],
+    "Transports": ["transports/graphql", "transports/rest"],
+    "Databases": ["databases/mongo", "databases/redis", "databases/typeorm"],
     "Strategies": [
       "strategies/password",
       "strategies/facebook",


### PR DESCRIPTION
I added a typeorm.md file copying from the mongo one.

Also listed both accounts-boost and the typeorm-postgres example on the examples/README.md

Fixed a typo on accounts-boost README with a double "two two" word. So meta, two times two. Hahaha

Close #682