### PR TITLE
Fix required properties of AccountsServerOptions

### DIFF
--- a/packages/server/src/types/accounts-server-options.ts
+++ b/packages/server/src/types/accounts-server-options.ts
@@ -11,8 +11,8 @@ export interface AccountsServerOptions {
    * Return ambiguous error messages from login failures to prevent user enumeration. Defaults to true.
    */
   ambiguousErrorMessages?: boolean;
-  db?: DatabaseInterface;
-  tokenSecret: string;
+  db: DatabaseInterface;
+  tokenSecret?: string;
   tokenConfigs?: {
     accessToken?: jwt.SignOptions;
     refreshToken?: jwt.SignOptions;


### PR DESCRIPTION
Tiny fix to require the `db` property, but make `tokenSecret` optional.

https://github.com/accounts-js/accounts/blob/master/packages/server/src/accounts-server.ts#L50-L58