### PR TITLE
[discuss] accounts-server token creator

### DIFF
--- a/packages/database-mongo/__tests__/index.ts
+++ b/packages/database-mongo/__tests__/index.ts
@@ -679,6 +679,33 @@ describe('Mongo', () => {
       expect(ret!.updatedAt).toBeTruthy();
       expect(ret!.createdAt).not.toEqual(ret!.updatedAt);
     });
+
+    it('should update session with token', async () => {
+      const token = generateRandomToken();
+      const token2 = generateRandomToken();
+      const sessionId = await databaseTests.database.createSession(session.userId, token, {
+        ip: session.ip,
+        userAgent: session.userAgent,
+      });
+      await delay(10);
+      await databaseTests.database.updateSession(
+        sessionId,
+        {
+          ip: 'new ip',
+          userAgent: 'new user agent',
+        },
+        token2
+      );
+      const ret = await databaseTests.database.findSessionById(sessionId);
+      expect(ret!.userId).toEqual(session.userId);
+      expect(ret!.ip).toEqual('new ip');
+      expect(ret!.userAgent).toEqual('new user agent');
+      expect(ret!.valid).toEqual(true);
+      expect(ret!.token).toEqual(token2);
+      expect(ret!.createdAt).toBeTruthy();
+      expect(ret!.updatedAt).toBeTruthy();
+      expect(ret!.createdAt).not.toEqual(ret!.updatedAt);
+    });
   });
 
   describe('invalidateSession', () => {

--- a/packages/server/__tests__/account-server.ts
+++ b/packages/server/__tests__/account-server.ts
@@ -570,7 +570,7 @@ describe('AccountsServer', () => {
             updateSession,
           } as any,
           tokenSecret: 'secret1',
-          createSessionTokenOnRefresh: true,
+          createNewSessionTokenOnRefresh: true,
           tokenCreator: {
             createToken: async () => {
               return '123';

--- a/packages/server/__tests__/account-server.ts
+++ b/packages/server/__tests__/account-server.ts
@@ -540,7 +540,60 @@ describe('AccountsServer', () => {
         refreshToken: 'newRefreshToken',
       });
       const res = await accountsServer.refreshTokens(accessToken, refreshToken, 'ip', 'user agent');
-      expect(updateSession.mock.calls[0]).toEqual(['456', { ip: 'ip', userAgent: 'user agent' }]);
+      expect(updateSession.mock.calls[0]).toEqual([
+        '456',
+        { ip: 'ip', userAgent: 'user agent' },
+        undefined,
+      ]);
+      expect((res as any).user).toEqual({
+        userId: '123',
+        username: 'username',
+      });
+    });
+
+    it('updates session and returns new tokens and user with new session token', async () => {
+      const updateSession = jest.fn(() => Promise.resolve());
+      const user = {
+        userId: '123',
+        username: 'username',
+      };
+      const accountsServer = new AccountsServer(
+        {
+          db: {
+            findSessionByToken: () =>
+              Promise.resolve({
+                id: '456',
+                valid: true,
+                userId: '123',
+              }),
+            findUserById: () => Promise.resolve(user),
+            updateSession,
+          } as any,
+          tokenSecret: 'secret1',
+          createSessionTokenOnRefresh: true,
+          tokenCreator: {
+            createToken: async () => {
+              return '123';
+            },
+          },
+        },
+        {}
+      );
+      const { accessToken, refreshToken } = accountsServer.createTokens({
+        token: '456',
+        userId: user.userId,
+      });
+      accountsServer.createTokens = () => ({
+        accessToken: 'newAccessToken',
+        refreshToken: 'newRefreshToken',
+      });
+
+      const res = await accountsServer.refreshTokens(accessToken, refreshToken, 'ip', 'user agent');
+      expect(updateSession.mock.calls[0]).toEqual([
+        '456',
+        { ip: 'ip', userAgent: 'user agent' },
+        '123',
+      ]);
       expect((res as any).user).toEqual({
         userId: '123',
         username: 'username',

--- a/packages/server/src/accounts-server.ts
+++ b/packages/server/src/accounts-server.ts
@@ -37,7 +37,7 @@ const defaultOptions = {
   userObjectSanitizer: (user: User) => user,
   sendMail,
   siteUrl: 'http://localhost:3000',
-  createSessionTokenOnRefresh: false,
+  createNewSessionTokenOnRefresh: false,
 };
 
 export class AccountsServer {
@@ -303,7 +303,7 @@ Please change it with a strong random token.`);
         }
 
         let newToken;
-        if (this.options.createSessionTokenOnRefresh) {
+        if (this.options.createNewSessionTokenOnRefresh) {
           newToken = await this.createSessionToken(user);
         }
 

--- a/packages/server/src/accounts-server.ts
+++ b/packages/server/src/accounts-server.ts
@@ -22,7 +22,7 @@ import { AccountsServerOptions } from './types/accounts-server-options';
 import { JwtData } from './types/jwt-data';
 import { EmailTemplateType } from './types/email-template-type';
 
-const defaultOptions = {
+const defaultOptions: AccountsServerOptions = {
   ambiguousErrorMessages: true,
   tokenSecret: 'secret',
   tokenConfigs: {
@@ -37,6 +37,7 @@ const defaultOptions = {
   userObjectSanitizer: (user: User) => user,
   sendMail,
   siteUrl: 'http://localhost:3000',
+  createSessionTokenOnRefresh: false,
 };
 
 export class AccountsServer {
@@ -138,7 +139,7 @@ Please change it with a strong random token.`);
    */
   public async loginWithUser(user: User, infos: ConnectionInformations): Promise<LoginResult> {
     const { ip, userAgent } = infos;
-    const token = generateRandomToken();
+    const token = await this.createSessionToken(user);
     const sessionId = await this.db.createSession(user.id, token, {
       ip,
       userAgent,
@@ -300,8 +301,14 @@ Please change it with a strong random token.`);
         if (!user) {
           throw new Error('User not found');
         }
-        const tokens = this.createTokens({ token: sessionToken, userId: user.id });
-        await this.db.updateSession(session.id, { ip, userAgent });
+
+        let newToken;
+        if (this.options.createSessionTokenOnRefresh) {
+          newToken = await this.createSessionToken(user);
+        }
+
+        const tokens = this.createTokens({ token: newToken || sessionToken, userId: user.id });
+        await this.db.updateSession(session.id, { ip, userAgent }, newToken);
 
         const result = {
           sessionId: session.id,
@@ -514,6 +521,12 @@ Please change it with a strong random token.`);
   private defaultCreateTokenizedUrl(pathFragment: string, token: string): string {
     const siteUrl = this.options.siteUrl;
     return `${siteUrl}/${pathFragment}/${token}`;
+  }
+
+  private async createSessionToken(user: User): Promise<string> {
+    return this.options.tokenCreator
+      ? this.options.tokenCreator.createToken(user)
+      : generateRandomToken();
   }
 }
 

--- a/packages/server/src/accounts-server.ts
+++ b/packages/server/src/accounts-server.ts
@@ -22,7 +22,7 @@ import { AccountsServerOptions } from './types/accounts-server-options';
 import { JwtData } from './types/jwt-data';
 import { EmailTemplateType } from './types/email-template-type';
 
-const defaultOptions: AccountsServerOptions = {
+const defaultOptions = {
   ambiguousErrorMessages: true,
   tokenSecret: 'secret',
   tokenConfigs: {

--- a/packages/server/src/types/accounts-server-options.ts
+++ b/packages/server/src/types/accounts-server-options.ts
@@ -26,5 +26,8 @@ export interface AccountsServerOptions {
   prepareMail?: PrepareMailFunction;
   sendMail?: SendMailType;
   tokenCreator?: TokenCreator;
-  createSessionTokenOnRefresh?: boolean;
+  /**
+   * Creates a new session token each time a user refreshes his access token
+   */
+  createNewSessionTokenOnRefresh?: boolean;
 }

--- a/packages/server/src/types/accounts-server-options.ts
+++ b/packages/server/src/types/accounts-server-options.ts
@@ -5,6 +5,7 @@ import { UserObjectSanitizerFunction } from './user-object-sanitizer-function';
 import { ResumeSessionValidator } from './resume-session-validator';
 import { PrepareMailFunction } from './prepare-mail-function';
 import { SendMailType } from './send-mail-type';
+import { TokenCreator } from './token-creator';
 
 export interface AccountsServerOptions {
   /**
@@ -24,4 +25,6 @@ export interface AccountsServerOptions {
   siteUrl?: string;
   prepareMail?: PrepareMailFunction;
   sendMail?: SendMailType;
+  tokenCreator?: TokenCreator;
+  createSessionTokenOnRefresh?: boolean;
 }

--- a/packages/server/src/types/token-creator.ts
+++ b/packages/server/src/types/token-creator.ts
@@ -1,0 +1,5 @@
+import { User } from '@accounts/types';
+
+export interface TokenCreator {
+  createToken(user: User): Promise<string>;
+}

--- a/packages/types/src/types/database-interface.ts
+++ b/packages/types/src/types/database-interface.ts
@@ -70,7 +70,11 @@ export interface DatabaseInterfaceSessions {
     extraData?: object
   ): Promise<string>;
 
-  updateSession(sessionId: string, connection: ConnectionInformations): Promise<void>;
+  updateSession(
+    sessionId: string,
+    connection: ConnectionInformations,
+    newToken?: string
+  ): Promise<void>;
 
   invalidateSession(sessionId: string): Promise<void>;
 


### PR DESCRIPTION
Hi,

In our project, we use a 3rd party authenticator service. This service manages access tokens itself. We wrote an `AuthenticationService` to support it, but it has duplicate code with `accounts-server` (and specific graphql endpoints) since we can't use its `loginWithService` and `refreshTokens` functionality.

The reason why we can't use `loginWithService` is the way we deliver our 3rd party token to the client. The only way for us to do that with `accountsjs` is to use it as a session token. then we create access token and refresh token using `accounts` and deliver them. since `accounts-server` generates the session token itself, `loginWithService` is not capable of supporting this scenario.

The way we thought of solving it, is to provide `accounts-server` with a custom `token creator` which will request the access token from the authenticator service and return it to be used as a session token.

The other problem is with `refreshTokens`. When the authenticator service tells us to refresh its tokens, we currently invalidate the current session and create a new one with the new access token. we want to be able to use `accountsServer` functionality to do that. that's why we want to add `createSessionTokenOnRefresh` option to create a new session token when refreshing tokens.

These two changes allow us to use more of accounts-server and client functionality without implementing it ourselves. 

@davidyaha @elie222 FYI