### PR TITLE
[@accounts/client-password] Remove client side hashing of the password, create docs for `client-password`

### DIFF
--- a/packages/client-password/__tests__/client-password.ts
+++ b/packages/client-password/__tests__/client-password.ts
@@ -21,6 +21,7 @@ const user = {
 describe('AccountsClientPassword', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.spyOn(accountsPassword, 'hashPassword');
   });
 
   it('requires the client', async () => {
@@ -51,17 +52,26 @@ describe('AccountsClientPassword', () => {
   describe('createUser', () => {
     it('should hash password and call transport', async () => {
       await accountsPassword.createUser(user);
-      expect(mockedClient.transport.createUser.mock.calls[0][0].email).toBe(user.email);
-      expect(mockedClient.transport.createUser.mock.calls[0][0].password).not.toBe(user.password);
+      expect(accountsPassword.hashPassword).toBeCalledTimes(1);
+      expect(accountsPassword.hashPassword).toBeCalledWith(user.password);
+      expect(mockedClient.transport.createUser).toBeCalledTimes(1);
+      expect(mockedClient.transport.createUser).toBeCalledWith({
+        email: user.email,
+        password: user.password,
+      });
     });
   });
 
   describe('login', () => {
     it('should hash password and call client', async () => {
       await accountsPassword.login(user);
-      expect(mockedClient.loginWithService.mock.calls[0][0]).toBe('password');
-      expect(mockedClient.loginWithService.mock.calls[0][1].email).toBe(user.email);
-      expect(mockedClient.loginWithService.mock.calls[0][1].password).not.toBe(user.password);
+      expect(accountsPassword.hashPassword).toBeCalledTimes(1);
+      expect(accountsPassword.hashPassword).toBeCalledWith(user.password);
+      expect(mockedClient.loginWithService).toBeCalledTimes(1);
+      expect(mockedClient.loginWithService).toBeCalledWith('password', {
+        email: user.email,
+        password: user.password,
+      });
     });
   });
 
@@ -77,8 +87,10 @@ describe('AccountsClientPassword', () => {
       const token = 'tokenTest';
       const newPassword = 'newPasswordTest';
       await accountsPassword.resetPassword(token, newPassword);
-      expect(mockedClient.transport.resetPassword.mock.calls[0][0]).toBe(token);
-      expect(mockedClient.transport.resetPassword.mock.calls[0][1]).not.toBe(newPassword);
+      expect(accountsPassword.hashPassword).toBeCalledTimes(1);
+      expect(accountsPassword.hashPassword).toBeCalledWith(newPassword);
+      expect(mockedClient.transport.resetPassword).toBeCalledTimes(1);
+      expect(mockedClient.transport.resetPassword).toBeCalledWith(token, newPassword);
     });
   });
 
@@ -100,8 +112,11 @@ describe('AccountsClientPassword', () => {
     it('should hash password and call transport', async () => {
       const newPassword = 'newPasswordTest';
       await accountsPassword.changePassword(user.password, newPassword);
-      expect(mockedClient.transport.changePassword.mock.calls[0][0]).not.toBe(user.password);
-      expect(mockedClient.transport.changePassword.mock.calls[0][1]).not.toBe(newPassword);
+      expect(accountsPassword.hashPassword).toBeCalledTimes(2);
+      expect(accountsPassword.hashPassword).toHaveBeenNthCalledWith(1, user.password);
+      expect(accountsPassword.hashPassword).toHaveBeenNthCalledWith(2, newPassword);
+      expect(mockedClient.transport.changePassword).toBeCalledTimes(1);
+      expect(mockedClient.transport.changePassword).toBeCalledWith(user.password, newPassword);
     });
   });
 });

--- a/packages/client-password/package.json
+++ b/packages/client-password/package.json
@@ -29,7 +29,6 @@
   "author": "Leo Pradel",
   "license": "MIT",
   "devDependencies": {
-    "@types/crypto-js": "3.1.43",
     "@types/jest": "24.0.16",
     "@types/node": "12.6.8",
     "jest": "24.8.0",
@@ -38,7 +37,6 @@
   "dependencies": {
     "@accounts/client": "^0.18.0",
     "@accounts/types": "^0.18.0",
-    "crypto-js": "^3.1.9-1",
     "tslib": "1.10.0"
   }
 }

--- a/packages/client-password/src/client-password.ts
+++ b/packages/client-password/src/client-password.ts
@@ -1,5 +1,4 @@
 import { AccountsClient } from '@accounts/client';
-import { SHA256 } from 'crypto-js';
 import { LoginResult, CreateUser } from '@accounts/types';
 import { AccountsClientPasswordOptions } from './types';
 
@@ -88,7 +87,6 @@ export class AccountsClientPassword {
     if (this.options.hashPassword) {
       return this.options.hashPassword(password);
     }
-    const hashedPassword = SHA256(password);
-    return hashedPassword.toString();
+    return password;
   }
 }

--- a/website/docs/strategies/password-client.md
+++ b/website/docs/strategies/password-client.md
@@ -1,0 +1,63 @@
+---
+id: password-client
+title: Password client
+sidebar_label: Client
+---
+
+[Github](https://github.com/accounts-js/accounts/tree/master/packages/client-password) |
+[npm](https://www.npmjs.com/package/@accounts/client-password)
+
+## Install
+
+```
+# With yarn
+yarn add @accounts/client-password
+
+# Or if you use npm
+npm install @accounts/client-password --save
+```
+
+## Usage
+
+```javascript
+import { AccountsClient } from '@accounts/client';
+import { AccountsClientPassword } from '@accounts/client-password';
+
+const accountsClient = new AccountsClient({}, myTransport);
+const accountsPassword = new AccountsClientPassword(accountsClient);
+```
+
+## Hashing the password client side
+
+⚠️ If your app is using https you probably don't need this since it won't add more security to your app. But if your app isn't using SSL you should really consider using client side hashing of the password to protect your users! But remember that every production app that handles user data should run with SSL.
+
+> This option was included in accounts-js by default until version `0.18.0`.
+
+First you will need to install the `crypto-js` npm library:
+
+```
+# With yarn
+yarn add crypto-js
+
+# Or if you use npm
+npm install crypto-js --save
+```
+
+Then setup the `hashPassword` option:
+
+```javascript
+import { SHA256 } from 'crypto-js';
+import { AccountsClient } from '@accounts/client';
+import { AccountsClientPassword } from '@accounts/client-password';
+
+const accountsClient = new AccountsClient({});
+const accountsPassword = new AccountsClientPassword(accountsClient, {
+  hashPassword: password => {
+    // Here we hash the password on the client before it's sent to the server
+    const hashedPassword = SHA256(password);
+    return hashedPassword.toString();
+  },
+});
+```
+
+Now when you login or create a user using `accountsPassword` the password will be hashed on the client so it won't be sent in plaintext to the server.

--- a/website/docs/strategies/password.md
+++ b/website/docs/strategies/password.md
@@ -1,5 +1,7 @@
 ---
+id: password
 title: Password
+sidebar_label: Server
 ---
 
 [Github](https://github.com/accounts-js/accounts/tree/master/packages/password) |

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -12,7 +12,11 @@ module.exports = {
     Transports: ['transports/graphql', 'transports/rest'],
     Databases: ['databases/mongo', 'databases/redis', 'databases/typeorm'],
     Strategies: [
-      'strategies/password',
+      {
+        type: 'category',
+        label: 'Password',
+        items: ['strategies/password', 'strategies/password-client'],
+      },
       'strategies/facebook',
       'strategies/oauth',
       'strategies/twitter',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1593,11 +1593,6 @@
   dependencies:
     "@types/express" "*"
 
-"@types/crypto-js@3.1.43":
-  version "3.1.43"
-  resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-3.1.43.tgz#b859347d6289ba13e347c335a4c9efa63337a748"
-  integrity sha512-EHe/YKctU3IYNBsDmSOPX/7jLHPRlx8WaiDKSY9JCTnJ8XJeM4c0ZJvx+9Gxmr2s2ihI92R+3U/gNL1sq5oRuQ==
-
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -4467,11 +4462,6 @@ crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
-
-crypto-js@^3.1.9-1:
-  version "3.1.9-1"
-  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.9-1.tgz#fda19e761fc077e01ffbfdc6e9fdfc59e8806cd8"
-  integrity sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=
 
 crypto-random-string@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## ⚠️ Breaking change

We decided to remove the client side hashing of the password by default. It does not provide more security if you use https, and is leading to some confusion.

In order to migrate to not break the login and registering of your existing user you will need to follow this migration:

First you will need to install the `crypto-js` npm library:

```
# With yarn
yarn add crypto-js
# Or if you use npm
npm install crypto-js --save
```

Then setup the `hashPassword` option:

```javascript
import { SHA256 } from 'crypto-js';
import { AccountsClient } from '@accounts/client';
import { AccountsClientPassword } from '@accounts/client-password';
const accountsClient = new AccountsClient({});
const accountsPassword = new AccountsClientPassword(accountsClient, {
  hashPassword: password => {
    // Here we hash the password on the client before it's sent to the server
    const hashedPassword = SHA256(password);
    return hashedPassword.toString();
  },
});
```