### PR TITLE
feat(accounts-client): provide an alternative client which is easier to configure & use [RFC]

### DIFF
--- a/packages/alt-client/accountsLink.ts
+++ b/packages/alt-client/accountsLink.ts
@@ -15,7 +15,7 @@ export const isTokenExpired = (token: string): boolean => {
   return decodedToken.exp < currentTime;
 };
 
-const accountsLink = (storage: StorageAdapter = localStorage, client: ApolloClient<any>) =>
+const accountsLink = (client: ApolloClient<any>, storage: StorageAdapter = localStorage) =>
   new ApolloLink((operation, forward) => {
     const accessToken = storage.get('accessToken');
     const refreshToken = storage.get('refreshToken');

--- a/packages/alt-client/accountsLink.ts
+++ b/packages/alt-client/accountsLink.ts
@@ -1,5 +1,5 @@
 import { ApolloLink } from 'apollo-link';
-import * as jwtDecode from 'jwt-decode';
+import jwtDecode from 'jwt-decode';
 import localStorage from './storage/localStorage';
 import { StorageAdapter } from './storage/interface';
 import { REFRESH_TOKEN, REFRESH_TOKEN_CALLBACK } from './mutations';
@@ -23,7 +23,7 @@ const accountsLink = (client: ApolloClient<any>, storage: StorageAdapter = local
       if (isTokenExpired(accessToken)) {
         if (refreshToken && !isTokenExpired(refreshToken)) {
           client
-            .mutate(REFRESH_TOKEN, { variables: { accessToken, refreshToken } })
+            .mutate({ mutation: REFRESH_TOKEN, variables: { accessToken, refreshToken } })
             .then(REFRESH_TOKEN_CALLBACK());
         } else {
           storage.remove('accessToken');

--- a/packages/alt-client/accountsLink.ts
+++ b/packages/alt-client/accountsLink.ts
@@ -24,7 +24,7 @@ const accountsLink = (client: ApolloClient<any>, storage: StorageAdapter = local
         if (refreshToken && !isTokenExpired(refreshToken)) {
           client
             .mutate(REFRESH_TOKEN, { variables: { accessToken, refreshToken } })
-            .then(REFRESH_TOKEN_CALLBACK);
+            .then(REFRESH_TOKEN_CALLBACK());
         } else {
           storage.remove('accessToken');
           storage.remove('refreshToken');

--- a/packages/alt-client/accountsLink.ts
+++ b/packages/alt-client/accountsLink.ts
@@ -1,0 +1,39 @@
+import { ApolloLink } from 'apollo-link';
+import * as jwtDecode from 'jwt-decode';
+import localStorage from './storage/localStorage';
+import { StorageAdapter } from './storage/interface';
+
+interface JwtDecodeData {
+  exp: number;
+  iat: number;
+}
+// take from aaccounts/client/utils
+export const isTokenExpired = (token: string): boolean => {
+  const currentTime = Date.now() / 1000;
+  const decodedToken = jwtDecode<JwtDecodeData>(token);
+  return decodedToken.exp < currentTime;
+};
+
+const accountsLink = (storage: StorageAdapter = localStorage, client: ApolloClient<any>) =>
+  new ApolloLink((operation, forward) => {
+    const accessToken = storage.get('accessToken');
+    const resumeToken = storage.get('resumeToken');
+    if (accessToken) {
+      if (isTokenExpired(accessToken)) {
+        if (resumeToken && !isTokenExpired(resumeToken)) {
+          client.mutate()
+        } else {
+          storage.remove('accessToken');
+          storage.remove('resumeToken');
+        }
+      }
+      operation.setContext(() => ({
+        headers: {
+          Authorization: 'Bearer ' + accessToken,
+        },
+      }));
+    }
+    return forward ? forward(operation) : null;
+  });
+
+export default accountsLink;

--- a/packages/alt-client/mutations.ts
+++ b/packages/alt-client/mutations.ts
@@ -1,0 +1,42 @@
+import gql from 'graphql-tag';
+import localStorage from './storage/localStorage';
+import { StorageAdapter } from './storage/interface';
+
+export const AUTHENTICATE = gql`
+  mutation authenticate($password: String!, $email: String!) {
+    authenticate(
+      params: { password: $password, user: { email: $email } }
+      serviceName: "password"
+    ) {
+      tokens {
+        accessToken
+        refreshToken
+      }
+    }
+  }
+`;
+
+export const AUTHENTICATE_CALLBACK = (storage: StorageAdapter = localStorage) => ({
+  data: { authenticate },
+}: any) => {
+  storage.set('accessToken', authenticate.tokens.accessToken);
+  storage.set('refreshToken', authenticate.tokens.refreshToken);
+};
+
+export const REFRESH_TOKEN = gql`
+  mutation refreshTokens($accessToken: String, $refreshToken: String) {
+    refreshTokens(accessToken: $accessToken, refreshToken: $refreshToken) {
+      tokens {
+        accessToken
+        refreshToken
+      }
+    }
+  }
+`;
+
+export const REFRESH_TOKEN_CALLBACK = (storage: StorageAdapter = localStorage) => ({
+  data: { refreshTokens },
+}: any) => {
+  storage.set('accessToken', refreshTokens.tokens.accessToken);
+  storage.set('refreshToken', refreshTokens.tokens.refreshToken);
+};

--- a/packages/alt-client/storage/interface.ts
+++ b/packages/alt-client/storage/interface.ts
@@ -1,0 +1,5 @@
+export interface StorageAdapter {
+  get(key: string): string | null;
+  set(key: string, value: string): void | string;
+  remove(key: string): void | null;
+}

--- a/packages/alt-client/storage/localStorage.ts
+++ b/packages/alt-client/storage/localStorage.ts
@@ -1,0 +1,9 @@
+import { StorageAdapter } from './interface';
+
+const lS: StorageAdapter = {
+  get: key => localStorage.getItem(key),
+  set: (key, value) => localStorage.setItem(key, value),
+  remove: key => localStorage.removeItem(key),
+};
+
+export default lS;


### PR DESCRIPTION
**Disclaimer:** This is a non-working poc. It was never intended to work. I just copied over some files from my repo so that I can easily showcase what I want to do without actually doing it :+1: 

I tried accounts-js today, and while I love the idea - I feel like configuring and using things is relatively complicated (mostly on the client side, but on the server as well). I don't like that style of passing configuration to configuration to configuration. Also this: https://github.com/accounts-js/accounts/blob/master/examples/react-graphql-typescript/src/utils/accounts.ts got slightly more complicated for me as I use `apollo-link-schema`, an `upload-link` and soem other fancy stuff.
Also I like the apollo-hooks style which I couldn't easily utilize with this package.

In order to fix that I ditched all the small client packages and started a raw monolith.
I hope I didn't forget to copy any files over, but in theory it works like this:

```
import { ApolloClient } from "apollo-client";
import AccountsLink from 'alt-client'

const client = new ApolloClient({
  link: ApolloLink.from([AccountsLink(client), ...allTheOtherLinks]]
});
```

For all the auth relevant methods (only did it for authenticate) one could provide a callback which handles the storage updates... so you can do things like
```
[login] = useMutation(AUTHENTICATE)
login({variables: {...}}).then(AUTHENTICATE_CALLBACK())
```

Please have and look and ping me in case it makes sense to evolve & integrate this in the repo somehow.