### PR TITLE
add force refreshTokens to client

### DIFF
--- a/packages/client/__tests__/accounts-client.ts
+++ b/packages/client/__tests__/accounts-client.ts
@@ -182,6 +182,20 @@ describe('Accounts', () => {
       expect(mockTransport.refreshTokens).not.toHaveBeenCalledWith();
     });
 
+    it('should call transport.refreshTokens if force is required and set the tokens', async () => {
+      (isTokenExpired as jest.Mock).mockImplementationOnce(() => false);
+      (isTokenExpired as jest.Mock).mockImplementationOnce(() => false);
+      await accountsClient.setTokens(tokens);
+      const result = await accountsClient.refreshSession(true);
+      expect(result).toEqual(loggedInResponse.tokens);
+      expect(isTokenExpired).toHaveBeenCalledWith(tokens.accessToken);
+      expect(mockTransport.refreshTokens).toHaveBeenCalledWith(
+        tokens.accessToken,
+        tokens.refreshToken
+      );
+      expect(localStorage.setItem).toHaveBeenCalledTimes(4);
+    });
+
     it('should clear the tokens is refreshToken is expired', async () => {
       (isTokenExpired as jest.Mock).mockImplementationOnce(() => false);
       (isTokenExpired as jest.Mock).mockImplementationOnce(() => true);

--- a/packages/client/src/accounts-client.ts
+++ b/packages/client/src/accounts-client.ts
@@ -102,14 +102,14 @@ export class AccountsClient {
    * Refresh the user session
    * If the tokens have expired try to refresh them
    */
-  public async refreshSession(): Promise<Tokens | null> {
+  public async refreshSession(force: boolean = false): Promise<Tokens | null> {
     const tokens = await this.getTokens();
     if (tokens) {
       try {
         const isAccessTokenExpired = isTokenExpired(tokens.accessToken);
         const isRefreshTokenExpired = isTokenExpired(tokens.refreshToken);
         // See if accessToken is expired and refreshToken is not
-        if (isAccessTokenExpired && !isRefreshTokenExpired) {
+        if ((force || isAccessTokenExpired) && !isRefreshTokenExpired) {
           // Request a new token pair
           const refreshedSession = await this.transport.refreshTokens(
             tokens.accessToken,


### PR DESCRIPTION
add the ability to force refreshing the client tokens.

followup of #774.

@davidyaha 