### PR TITLE
graphql-toolkit version bump to 0.5.17 to fix `await` issue

### DIFF
--- a/packages/graphql-api/package.json
+++ b/packages/graphql-api/package.json
@@ -58,7 +58,7 @@
     "graphql-tools": "^4.0.5"
   },
   "dependencies": {
-    "graphql-toolkit": "^0.5.12",
+    "graphql-toolkit": "^0.5.17",
     "request-ip": "2.1.3",
     "tslib": "1.10.0"
   }


### PR DESCRIPTION
Currently hitting this https://github.com/ardatan/graphql-toolkit/issues/259 issue with the 0.5.12 version of graphql-toolkit. Upgrading in an attempt to solve https://github.com/accounts-js/accounts/issues/836