### PR TITLE
feat(server): allow tokenSecret to accept a pair of public / private key

### DIFF
--- a/examples/accounts-boost/src/monolithic/app-server.ts
+++ b/examples/accounts-boost/src/monolithic/app-server.ts
@@ -3,9 +3,11 @@ import { mergeTypeDefs, mergeResolvers } from 'graphql-toolkit';
 import { ApolloServer } from 'apollo-server';
 
 (async () => {
-  const accounts = (await accountsBoost({
-    tokenSecret: 'terrible secret',
-  })).graphql();
+  const accounts = (
+    await accountsBoost({
+      tokenSecret: 'terrible secret',
+    })
+  ).graphql();
 
   const typeDefs = `
     type PrivateType @auth {

--- a/packages/boost/src/index.ts
+++ b/packages/boost/src/index.ts
@@ -150,7 +150,11 @@ export class AccountsBoost {
         }
 
         try {
-          decoded = verify(accessToken, this.options.tokenSecret);
+          const secretOrPublicKey =
+            typeof this.options.tokenSecret === 'string'
+              ? this.options.tokenSecret
+              : this.options.tokenSecret.publicKey;
+          decoded = verify(accessToken, secretOrPublicKey);
         } catch (err) {
           throw new Error('Access token is not valid');
         }

--- a/packages/server/__tests__/account-server.ts
+++ b/packages/server/__tests__/account-server.ts
@@ -178,10 +178,7 @@ describe('AccountsServer', () => {
         {}
       );
 
-      const { accessToken } = await accountsServer.createTokens({
-        token: '456',
-        userId: user.userId,
-      });
+      const { accessToken } = accountsServer.createTokens({ token: '456', userId: user.userId });
       await accountsServer.logout(accessToken);
       expect(invalidateSession).toHaveBeenCalledWith('456');
     });
@@ -285,10 +282,7 @@ describe('AccountsServer', () => {
       );
       accountsServer.on(ServerHooks.LogoutSuccess, hookSpy);
 
-      const { accessToken } = await accountsServer.createTokens({
-        token: '456',
-        userId: user.userId,
-      });
+      const { accessToken } = accountsServer.createTokens({ token: '456', userId: user.userId });
       await accountsServer.logout(accessToken);
       await delay(10);
       expect(hookSpy).toHaveBeenCalled();
@@ -314,7 +308,7 @@ describe('AccountsServer', () => {
       accountsServer.on(ServerHooks.LogoutError, hookSpy);
 
       try {
-        const { accessToken } = await accountsServer.createTokens({ token: '456', userId: '122' });
+        const { accessToken } = accountsServer.createTokens({ token: '456', userId: '122' });
         await accountsServer.logout(accessToken);
       } catch (err) {
         // nothing to do
@@ -347,10 +341,7 @@ describe('AccountsServer', () => {
       );
       accountsServer.on(ServerHooks.ResumeSessionSuccess, hookSpy);
 
-      const { accessToken } = await accountsServer.createTokens({
-        token: '456',
-        userId: user.userId,
-      });
+      const { accessToken } = accountsServer.createTokens({ token: '456', userId: user.userId });
       await accountsServer.resumeSession(accessToken);
       await delay(10);
       expect(hookSpy).toHaveBeenCalled();
@@ -380,10 +371,7 @@ describe('AccountsServer', () => {
       );
       accountsServer.on(ServerHooks.ResumeSessionError, hookSpy);
 
-      const { accessToken } = await accountsServer.createTokens({
-        token: '456',
-        userId: user.userId,
-      });
+      const { accessToken } = accountsServer.createTokens({ token: '456', userId: user.userId });
 
       try {
         await accountsServer.resumeSession(accessToken);
@@ -413,10 +401,7 @@ describe('AccountsServer', () => {
       );
       accountsServer.on(ServerHooks.ResumeSessionError, hookSpy);
 
-      const { accessToken } = await accountsServer.createTokens({
-        token: '456',
-        userId: user.userId,
-      });
+      const { accessToken } = accountsServer.createTokens({ token: '456', userId: user.userId });
 
       try {
         await accountsServer.resumeSession(accessToken);
@@ -444,7 +429,7 @@ describe('AccountsServer', () => {
       accountsServer.on(ServerHooks.RefreshTokensError, hookSpy);
 
       try {
-        const { accessToken, refreshToken } = await accountsServer.createTokens({
+        const { accessToken, refreshToken } = accountsServer.createTokens({
           token: '456',
           userId: 'userId',
         });
@@ -480,11 +465,11 @@ describe('AccountsServer', () => {
       );
       accountsServer.on(ServerHooks.RefreshTokensSuccess, hookSpy);
 
-      const { accessToken, refreshToken } = await accountsServer.createTokens({
+      const { accessToken, refreshToken } = accountsServer.createTokens({
         token: '456',
         userId: user.userId,
       });
-      accountsServer.createTokens = async () => ({
+      accountsServer.createTokens = () => ({
         accessToken: 'newAccessToken',
         refreshToken: 'newRefreshToken',
       });
@@ -534,7 +519,7 @@ describe('AccountsServer', () => {
         },
         {}
       );
-      const { accessToken } = await accountsServer.createTokens({ token: '456', userId: user.id });
+      const { accessToken } = accountsServer.createTokens({ token: '456', userId: user.id });
       const hookSpy = jest.fn(() => null);
       accountsServer.on(ServerHooks.ImpersonationSuccess, hookSpy);
 
@@ -579,11 +564,11 @@ describe('AccountsServer', () => {
         },
         {}
       );
-      const { accessToken, refreshToken } = await accountsServer.createTokens({
+      const { accessToken, refreshToken } = accountsServer.createTokens({
         token: '456',
         userId: user.userId,
       });
-      accountsServer.createTokens = async () => ({
+      accountsServer.createTokens = () => ({
         accessToken: 'newAccessToken',
         refreshToken: 'newRefreshToken',
       });
@@ -627,11 +612,11 @@ describe('AccountsServer', () => {
         },
         {}
       );
-      const { accessToken, refreshToken } = await accountsServer.createTokens({
+      const { accessToken, refreshToken } = accountsServer.createTokens({
         token: '456',
         userId: user.userId,
       });
-      accountsServer.createTokens = async () => ({
+      accountsServer.createTokens = () => ({
         accessToken: 'newAccessToken',
         refreshToken: 'newRefreshToken',
       });
@@ -683,7 +668,7 @@ describe('AccountsServer', () => {
         },
         {}
       );
-      const { accessToken, refreshToken } = await accountsServer.createTokens({
+      const { accessToken, refreshToken } = accountsServer.createTokens({
         token: '123',
         userId: '213',
       });
@@ -705,7 +690,7 @@ describe('AccountsServer', () => {
         },
         {}
       );
-      const { accessToken, refreshToken } = await accountsServer.createTokens({
+      const { accessToken, refreshToken } = accountsServer.createTokens({
         token: '456',
         userId: 'user',
       });
@@ -731,7 +716,7 @@ describe('AccountsServer', () => {
         {}
       );
 
-      const { accessToken, refreshToken } = await accountsServer.createTokens({
+      const { accessToken, refreshToken } = accountsServer.createTokens({
         token: '456',
         userId: 'user',
       });
@@ -779,7 +764,7 @@ describe('AccountsServer', () => {
         {}
       );
 
-      const { accessToken } = await accountsServer.createTokens({
+      const { accessToken } = accountsServer.createTokens({
         token: '456',
         userId: 'user',
       });
@@ -799,7 +784,7 @@ describe('AccountsServer', () => {
         },
         {}
       );
-      const { accessToken } = await accountsServer.createTokens({
+      const { accessToken } = accountsServer.createTokens({
         token: '456',
         userId: 'user',
       });
@@ -843,7 +828,7 @@ describe('AccountsServer', () => {
         {}
       );
 
-      const { accessToken } = await accountsServer.createTokens({ token: '456', userId: 'user' });
+      const { accessToken } = accountsServer.createTokens({ token: '456', userId: 'user' });
       await expect(accountsServer.resumeSession(accessToken)).rejects.toThrowError(
         'User not found'
       );
@@ -870,10 +855,7 @@ describe('AccountsServer', () => {
         {}
       );
 
-      const { accessToken } = await accountsServer.createTokens({
-        token: '456',
-        userId: user.userId,
-      });
+      const { accessToken } = accountsServer.createTokens({ token: '456', userId: user.userId });
       await expect(accountsServer.resumeSession(accessToken)).rejects.toThrowError(
         'Invalid Session'
       );
@@ -900,10 +882,7 @@ describe('AccountsServer', () => {
         {}
       );
 
-      const { accessToken } = await accountsServer.createTokens({
-        token: '456',
-        userId: user.userId,
-      });
+      const { accessToken } = accountsServer.createTokens({ token: '456', userId: user.userId });
       const foundUser = await accountsServer.resumeSession(accessToken);
       expect(foundUser).toEqual(user);
     });
@@ -982,7 +961,7 @@ describe('AccountsServer', () => {
         },
         {}
       );
-      const { accessToken } = await accountsServer.createTokens({ token: '456', userId: 'user' });
+      const { accessToken } = accountsServer.createTokens({ token: '456', userId: 'user' });
 
       accountsServer.findSessionByAccessToken = () =>
         Promise.resolve({
@@ -1005,7 +984,7 @@ describe('AccountsServer', () => {
         },
         {}
       );
-      const { accessToken } = await accountsServer.createTokens({ token: '456', userId: 'user' });
+      const { accessToken } = accountsServer.createTokens({ token: '456', userId: 'user' });
 
       accountsServer.findSessionByAccessToken = () =>
         Promise.resolve({
@@ -1032,7 +1011,7 @@ describe('AccountsServer', () => {
         },
         {}
       );
-      const { accessToken } = await accountsServer.createTokens({ token: '456', userId: 'user' });
+      const { accessToken } = accountsServer.createTokens({ token: '456', userId: 'user' });
 
       accountsServer.findSessionByAccessToken = () =>
         Promise.resolve({
@@ -1056,7 +1035,7 @@ describe('AccountsServer', () => {
         },
         {}
       );
-      const { accessToken } = await accountsServer.createTokens({ token: '456', userId: 'user' });
+      const { accessToken } = accountsServer.createTokens({ token: '456', userId: 'user' });
 
       accountsServer.findSessionByAccessToken = () =>
         Promise.resolve({
@@ -1087,7 +1066,7 @@ describe('AccountsServer', () => {
         },
         {}
       );
-      const { accessToken } = await accountsServer.createTokens({ token: '456', userId: 'user' });
+      const { accessToken } = accountsServer.createTokens({ token: '456', userId: 'user' });
 
       accountsServer.findSessionByAccessToken = () =>
         Promise.resolve({
@@ -1124,7 +1103,7 @@ describe('AccountsServer', () => {
         },
         {}
       );
-      const { accessToken } = await accountsServer.createTokens({ token: '456', userId: user.id });
+      const { accessToken } = accountsServer.createTokens({ token: '456', userId: user.id });
 
       accountsServer.findSessionByAccessToken = () =>
         Promise.resolve({

--- a/packages/server/__tests__/account-server.ts
+++ b/packages/server/__tests__/account-server.ts
@@ -178,7 +178,10 @@ describe('AccountsServer', () => {
         {}
       );
 
-      const { accessToken } = accountsServer.createTokens({ token: '456', userId: user.userId });
+      const { accessToken } = await accountsServer.createTokens({
+        token: '456',
+        userId: user.userId,
+      });
       await accountsServer.logout(accessToken);
       expect(invalidateSession).toHaveBeenCalledWith('456');
     });
@@ -282,7 +285,10 @@ describe('AccountsServer', () => {
       );
       accountsServer.on(ServerHooks.LogoutSuccess, hookSpy);
 
-      const { accessToken } = accountsServer.createTokens({ token: '456', userId: user.userId });
+      const { accessToken } = await accountsServer.createTokens({
+        token: '456',
+        userId: user.userId,
+      });
       await accountsServer.logout(accessToken);
       await delay(10);
       expect(hookSpy).toHaveBeenCalled();
@@ -308,7 +314,7 @@ describe('AccountsServer', () => {
       accountsServer.on(ServerHooks.LogoutError, hookSpy);
 
       try {
-        const { accessToken } = accountsServer.createTokens({ token: '456', userId: '122' });
+        const { accessToken } = await accountsServer.createTokens({ token: '456', userId: '122' });
         await accountsServer.logout(accessToken);
       } catch (err) {
         // nothing to do
@@ -341,7 +347,10 @@ describe('AccountsServer', () => {
       );
       accountsServer.on(ServerHooks.ResumeSessionSuccess, hookSpy);
 
-      const { accessToken } = accountsServer.createTokens({ token: '456', userId: user.userId });
+      const { accessToken } = await accountsServer.createTokens({
+        token: '456',
+        userId: user.userId,
+      });
       await accountsServer.resumeSession(accessToken);
       await delay(10);
       expect(hookSpy).toHaveBeenCalled();
@@ -371,7 +380,10 @@ describe('AccountsServer', () => {
       );
       accountsServer.on(ServerHooks.ResumeSessionError, hookSpy);
 
-      const { accessToken } = accountsServer.createTokens({ token: '456', userId: user.userId });
+      const { accessToken } = await accountsServer.createTokens({
+        token: '456',
+        userId: user.userId,
+      });
 
       try {
         await accountsServer.resumeSession(accessToken);
@@ -401,7 +413,10 @@ describe('AccountsServer', () => {
       );
       accountsServer.on(ServerHooks.ResumeSessionError, hookSpy);
 
-      const { accessToken } = accountsServer.createTokens({ token: '456', userId: user.userId });
+      const { accessToken } = await accountsServer.createTokens({
+        token: '456',
+        userId: user.userId,
+      });
 
       try {
         await accountsServer.resumeSession(accessToken);
@@ -429,7 +444,7 @@ describe('AccountsServer', () => {
       accountsServer.on(ServerHooks.RefreshTokensError, hookSpy);
 
       try {
-        const { accessToken, refreshToken } = accountsServer.createTokens({
+        const { accessToken, refreshToken } = await accountsServer.createTokens({
           token: '456',
           userId: 'userId',
         });
@@ -465,11 +480,11 @@ describe('AccountsServer', () => {
       );
       accountsServer.on(ServerHooks.RefreshTokensSuccess, hookSpy);
 
-      const { accessToken, refreshToken } = accountsServer.createTokens({
+      const { accessToken, refreshToken } = await accountsServer.createTokens({
         token: '456',
         userId: user.userId,
       });
-      accountsServer.createTokens = () => ({
+      accountsServer.createTokens = async () => ({
         accessToken: 'newAccessToken',
         refreshToken: 'newRefreshToken',
       });
@@ -519,7 +534,7 @@ describe('AccountsServer', () => {
         },
         {}
       );
-      const { accessToken } = accountsServer.createTokens({ token: '456', userId: user.id });
+      const { accessToken } = await accountsServer.createTokens({ token: '456', userId: user.id });
       const hookSpy = jest.fn(() => null);
       accountsServer.on(ServerHooks.ImpersonationSuccess, hookSpy);
 
@@ -564,11 +579,11 @@ describe('AccountsServer', () => {
         },
         {}
       );
-      const { accessToken, refreshToken } = accountsServer.createTokens({
+      const { accessToken, refreshToken } = await accountsServer.createTokens({
         token: '456',
         userId: user.userId,
       });
-      accountsServer.createTokens = () => ({
+      accountsServer.createTokens = async () => ({
         accessToken: 'newAccessToken',
         refreshToken: 'newRefreshToken',
       });
@@ -612,11 +627,11 @@ describe('AccountsServer', () => {
         },
         {}
       );
-      const { accessToken, refreshToken } = accountsServer.createTokens({
+      const { accessToken, refreshToken } = await accountsServer.createTokens({
         token: '456',
         userId: user.userId,
       });
-      accountsServer.createTokens = () => ({
+      accountsServer.createTokens = async () => ({
         accessToken: 'newAccessToken',
         refreshToken: 'newRefreshToken',
       });
@@ -668,7 +683,7 @@ describe('AccountsServer', () => {
         },
         {}
       );
-      const { accessToken, refreshToken } = accountsServer.createTokens({
+      const { accessToken, refreshToken } = await accountsServer.createTokens({
         token: '123',
         userId: '213',
       });
@@ -690,7 +705,7 @@ describe('AccountsServer', () => {
         },
         {}
       );
-      const { accessToken, refreshToken } = accountsServer.createTokens({
+      const { accessToken, refreshToken } = await accountsServer.createTokens({
         token: '456',
         userId: 'user',
       });
@@ -716,7 +731,7 @@ describe('AccountsServer', () => {
         {}
       );
 
-      const { accessToken, refreshToken } = accountsServer.createTokens({
+      const { accessToken, refreshToken } = await accountsServer.createTokens({
         token: '456',
         userId: 'user',
       });
@@ -764,7 +779,7 @@ describe('AccountsServer', () => {
         {}
       );
 
-      const { accessToken } = accountsServer.createTokens({
+      const { accessToken } = await accountsServer.createTokens({
         token: '456',
         userId: 'user',
       });
@@ -784,7 +799,7 @@ describe('AccountsServer', () => {
         },
         {}
       );
-      const { accessToken } = accountsServer.createTokens({
+      const { accessToken } = await accountsServer.createTokens({
         token: '456',
         userId: 'user',
       });
@@ -828,7 +843,7 @@ describe('AccountsServer', () => {
         {}
       );
 
-      const { accessToken } = accountsServer.createTokens({ token: '456', userId: 'user' });
+      const { accessToken } = await accountsServer.createTokens({ token: '456', userId: 'user' });
       await expect(accountsServer.resumeSession(accessToken)).rejects.toThrowError(
         'User not found'
       );
@@ -855,7 +870,10 @@ describe('AccountsServer', () => {
         {}
       );
 
-      const { accessToken } = accountsServer.createTokens({ token: '456', userId: user.userId });
+      const { accessToken } = await accountsServer.createTokens({
+        token: '456',
+        userId: user.userId,
+      });
       await expect(accountsServer.resumeSession(accessToken)).rejects.toThrowError(
         'Invalid Session'
       );
@@ -882,7 +900,10 @@ describe('AccountsServer', () => {
         {}
       );
 
-      const { accessToken } = accountsServer.createTokens({ token: '456', userId: user.userId });
+      const { accessToken } = await accountsServer.createTokens({
+        token: '456',
+        userId: user.userId,
+      });
       const foundUser = await accountsServer.resumeSession(accessToken);
       expect(foundUser).toEqual(user);
     });
@@ -961,7 +982,7 @@ describe('AccountsServer', () => {
         },
         {}
       );
-      const { accessToken } = accountsServer.createTokens({ token: '456', userId: 'user' });
+      const { accessToken } = await accountsServer.createTokens({ token: '456', userId: 'user' });
 
       accountsServer.findSessionByAccessToken = () =>
         Promise.resolve({
@@ -984,7 +1005,7 @@ describe('AccountsServer', () => {
         },
         {}
       );
-      const { accessToken } = accountsServer.createTokens({ token: '456', userId: 'user' });
+      const { accessToken } = await accountsServer.createTokens({ token: '456', userId: 'user' });
 
       accountsServer.findSessionByAccessToken = () =>
         Promise.resolve({
@@ -1011,7 +1032,7 @@ describe('AccountsServer', () => {
         },
         {}
       );
-      const { accessToken } = accountsServer.createTokens({ token: '456', userId: 'user' });
+      const { accessToken } = await accountsServer.createTokens({ token: '456', userId: 'user' });
 
       accountsServer.findSessionByAccessToken = () =>
         Promise.resolve({
@@ -1035,7 +1056,7 @@ describe('AccountsServer', () => {
         },
         {}
       );
-      const { accessToken } = accountsServer.createTokens({ token: '456', userId: 'user' });
+      const { accessToken } = await accountsServer.createTokens({ token: '456', userId: 'user' });
 
       accountsServer.findSessionByAccessToken = () =>
         Promise.resolve({
@@ -1066,7 +1087,7 @@ describe('AccountsServer', () => {
         },
         {}
       );
-      const { accessToken } = accountsServer.createTokens({ token: '456', userId: 'user' });
+      const { accessToken } = await accountsServer.createTokens({ token: '456', userId: 'user' });
 
       accountsServer.findSessionByAccessToken = () =>
         Promise.resolve({
@@ -1103,7 +1124,7 @@ describe('AccountsServer', () => {
         },
         {}
       );
-      const { accessToken } = accountsServer.createTokens({ token: '456', userId: user.id });
+      const { accessToken } = await accountsServer.createTokens({ token: '456', userId: user.id });
 
       accountsServer.findSessionByAccessToken = () =>
         Promise.resolve({
@@ -1164,6 +1185,60 @@ describe('AccountsServer', () => {
       );
       const modifiedUser = accountsServer.sanitizeUser(userObject);
       expect(modifiedUser.username).toBeUndefined();
+    });
+  });
+
+  describe('getSecretOrPublicKey', () => {
+    it('return secert', async () => {
+      const accountsServer: any = new AccountsServer(
+        {
+          db: {} as any,
+          tokenSecret: 'secret1',
+        },
+        {}
+      );
+      expect(accountsServer.getSecretOrPublicKey()).toEqual('secret1');
+    });
+
+    it('return public key', async () => {
+      const accountsServer: any = new AccountsServer(
+        {
+          db: {} as any,
+          tokenSecret: {
+            publicKey: 'publicKey1',
+            privateKey: 'privateKey1',
+          },
+        },
+        {}
+      );
+      expect(accountsServer.getSecretOrPublicKey()).toEqual('publicKey1');
+    });
+  });
+
+  describe('getSecretOrPrivateKey', () => {
+    it('return secert', async () => {
+      const accountsServer: any = new AccountsServer(
+        {
+          db: {} as any,
+          tokenSecret: 'secret1',
+        },
+        {}
+      );
+      expect(accountsServer.getSecretOrPrivateKey()).toEqual('secret1');
+    });
+
+    it('return private key', async () => {
+      const accountsServer: any = new AccountsServer(
+        {
+          db: {} as any,
+          tokenSecret: {
+            publicKey: 'publicKey1',
+            privateKey: 'privateKey1',
+          },
+        },
+        {}
+      );
+      expect(accountsServer.getSecretOrPrivateKey()).toEqual('privateKey1');
     });
   });
 });

--- a/packages/server/src/accounts-server.ts
+++ b/packages/server/src/accounts-server.ts
@@ -187,7 +187,7 @@ Please change it with a strong random token.`);
       userAgent,
     });
 
-    const { accessToken, refreshToken } = await this.createTokens({
+    const { accessToken, refreshToken } = this.createTokens({
       token,
       userId: user.id,
     });
@@ -279,7 +279,7 @@ Please change it with a strong random token.`);
         { impersonatorUserId: user.id }
       );
 
-      const impersonationTokens = await this.createTokens({
+      const impersonationTokens = this.createTokens({
         token: newSessionId,
         isImpersonated: true,
         userId: user.id,
@@ -349,10 +349,7 @@ Please change it with a strong random token.`);
           newToken = await this.createSessionToken(user);
         }
 
-        const tokens = await this.createTokens({
-          token: newToken || sessionToken,
-          userId: user.id,
-        });
+        const tokens = this.createTokens({ token: newToken || sessionToken, userId: user.id });
         await this.db.updateSession(session.id, { ip, userAgent }, newToken);
 
         const result = {
@@ -378,9 +375,9 @@ Please change it with a strong random token.`);
    * @description Refresh a user token.
    * @param {string} token - User session token.
    * @param {boolean} isImpersonated - Should be true if impersonating another user.
-   * @returns {Promise<Tokens>} - Return a new accessToken and refreshToken.
+   * @returns {<Tokens>} - Return a new accessToken and refreshToken.
    */
-  public async createTokens({
+  public createTokens({
     token,
     isImpersonated = false,
     userId,
@@ -388,7 +385,7 @@ Please change it with a strong random token.`);
     token: string;
     isImpersonated?: boolean;
     userId: string;
-  }): Promise<Tokens> {
+  }): Tokens {
     const { tokenConfigs } = this.options;
     const jwtData: JwtData = {
       token,

--- a/packages/server/src/types/accounts-server-options.ts
+++ b/packages/server/src/types/accounts-server-options.ts
@@ -13,7 +13,12 @@ export interface AccountsServerOptions {
    */
   ambiguousErrorMessages?: boolean;
   db?: DatabaseInterface;
-  tokenSecret: string;
+  tokenSecret:
+    | string
+    | {
+        publicKey: jwt.Secret;
+        privateKey: jwt.Secret;
+      };
   tokenConfigs?: {
     accessToken?: jwt.SignOptions;
     refreshToken?: jwt.SignOptions;

--- a/packages/server/src/utils/tokens.ts
+++ b/packages/server/src/utils/tokens.ts
@@ -11,7 +11,7 @@ export const generateAccessToken = ({
   data,
   config,
 }: {
-  secret: string;
+  secret: jwt.Secret;
   data?: any;
   config: jwt.SignOptions;
 }) =>
@@ -28,7 +28,7 @@ export const generateRefreshToken = ({
   data,
   config,
 }: {
-  secret: string;
+  secret: jwt.Secret;
   data?: any;
   config: jwt.SignOptions;
 }) =>


### PR DESCRIPTION
Our project want to use RS256 in jwt signing, which use a pair of public / private key instead of a single string secret, and also we want to override `createTokens` function to add custom logic. So making the following changes in this pull request:

1. Allow `tokenSecret` to accept a pair of public / private key instead of a single string secret, and add two private function `getSecretOrPublicKey` and `getSecretOrPrivateKey` to get string secret or public / private key when sign or verify jwt.
2. ~~Make `createTokens` function become async, so when override `createTokens` function, async functions can be easily added.~~