### PR TITLE
[@accounts/password] Expose `addEmail` to the client

### DIFF
--- a/examples/react-rest-typescript/src/Email.tsx
+++ b/examples/react-rest-typescript/src/Email.tsx
@@ -13,6 +13,7 @@ import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord';
 import SendIcon from '@material-ui/icons/Send';
 import { accountsClient, accountsRest } from './accounts';
 import { AuthenticatedContainer } from './components/AuthenticatedContainer';
+import { User } from '@accounts/types';
 
 const useStyles = makeStyles(theme => ({
   divider: {
@@ -43,7 +44,7 @@ const useStyles = makeStyles(theme => ({
 
 export const Email = () => {
   const classes = useStyles();
-  const [user, setUser] = useState();
+  const [user, setUser] = useState<User>();
 
   useEffect(() => {
     fetchUser();
@@ -55,8 +56,8 @@ export const Email = () => {
     setUser(user);
   };
 
-  const onResendEmail = async () => {
-    await accountsRest.sendVerificationEmail(user.emails[0].address);
+  const onResendEmail = async (address: string) => {
+    await accountsRest.sendVerificationEmail(address);
     alert('Verification email sent');
   };
 
@@ -71,32 +72,33 @@ export const Email = () => {
         <CardHeader subheader="Emails" className={classes.cardHeader} />
         <Divider />
         <CardContent className={classes.cardContent}>
-          {user.emails.map((email: any, index: number) => (
-            <div key={index} className={classes.emailItem}>
-              <div className={classes.emailItemPart}>
-                <Tooltip
-                  arrow
-                  placement="top-start"
-                  title={
-                    email.verified ? 'Your email is verified' : 'You need to verify your email'
-                  }
-                >
-                  <FiberManualRecordIcon
-                    className={classes.emailItemDot}
-                    color={email.verified ? 'secondary' : 'error'}
-                  />
-                </Tooltip>
-                <Typography>{email.address}</Typography>
+          {user.emails &&
+            user.emails.map(email => (
+              <div key={email.address} className={classes.emailItem}>
+                <div className={classes.emailItemPart}>
+                  <Tooltip
+                    arrow
+                    placement="top-start"
+                    title={
+                      email.verified ? 'Your email is verified' : 'You need to verify your email'
+                    }
+                  >
+                    <FiberManualRecordIcon
+                      className={classes.emailItemDot}
+                      color={email.verified ? 'secondary' : 'error'}
+                    />
+                  </Tooltip>
+                  <Typography>{email.address}</Typography>
+                </div>
+                {!email.verified && (
+                  <Tooltip arrow placement="top-end" title="Resend verification email">
+                    <IconButton aria-label="Send" onClick={() => onResendEmail(email.address)}>
+                      <SendIcon />
+                    </IconButton>
+                  </Tooltip>
+                )}
               </div>
-              {!email.verified && (
-                <Tooltip arrow placement="top-end" title="Resend verification email">
-                  <IconButton aria-label="Send" onClick={onResendEmail}>
-                    <SendIcon />
-                  </IconButton>
-                </Tooltip>
-              )}
-            </div>
-          ))}
+            ))}
         </CardContent>
       </Card>
     </AuthenticatedContainer>

--- a/examples/react-rest-typescript/src/Email.tsx
+++ b/examples/react-rest-typescript/src/Email.tsx
@@ -17,7 +17,7 @@ import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord';
 import SendIcon from '@material-ui/icons/Send';
 import { useFormik, FormikErrors } from 'formik';
 import { User } from '@accounts/types';
-import { accountsClient, accountsRest } from './accounts';
+import { accountsClient, accountsRest, accountsPassword } from './accounts';
 import { AuthenticatedContainer } from './components/AuthenticatedContainer';
 
 const useStyles = makeStyles(theme => ({
@@ -41,6 +41,7 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
+    minHeight: 48,
   },
   emailItemPart: {
     display: 'flex',
@@ -70,8 +71,9 @@ export const Email = () => {
     },
     onSubmit: async (values, { setSubmitting }) => {
       try {
-        // TODO send email to server
-        // TODO refetch user to show the new email
+        await accountsPassword.addEmail(values.newEmail);
+        await fetchUser();
+        alert('New email added');
       } catch (error) {
         alert(error);
       }

--- a/examples/react-rest-typescript/src/Email.tsx
+++ b/examples/react-rest-typescript/src/Email.tsx
@@ -8,12 +8,17 @@ import {
   Divider,
   Tooltip,
   IconButton,
+  CardActions,
+  Button,
+  Grid,
+  TextField,
 } from '@material-ui/core';
 import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord';
 import SendIcon from '@material-ui/icons/Send';
+import { useFormik, FormikErrors } from 'formik';
+import { User } from '@accounts/types';
 import { accountsClient, accountsRest } from './accounts';
 import { AuthenticatedContainer } from './components/AuthenticatedContainer';
-import { User } from '@accounts/types';
 
 const useStyles = makeStyles(theme => ({
   divider: {
@@ -29,6 +34,9 @@ const useStyles = makeStyles(theme => ({
   cardContent: {
     padding: theme.spacing(3),
   },
+  cardActions: {
+    padding: theme.spacing(3),
+  },
   emailItem: {
     display: 'flex',
     alignItems: 'center',
@@ -42,9 +50,34 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+interface AddEmailValues {
+  newEmail: string;
+}
+
 export const Email = () => {
   const classes = useStyles();
   const [user, setUser] = useState<User>();
+  const formik = useFormik<AddEmailValues>({
+    initialValues: {
+      newEmail: '',
+    },
+    validate: values => {
+      const errors: FormikErrors<AddEmailValues> = {};
+      if (!values.newEmail) {
+        errors.newEmail = 'Required';
+      }
+      return errors;
+    },
+    onSubmit: async (values, { setSubmitting }) => {
+      try {
+        // TODO send email to server
+        // TODO refetch user to show the new email
+      } catch (error) {
+        alert(error);
+      }
+      setSubmitting(false);
+    },
+  });
 
   useEffect(() => {
     fetchUser();
@@ -100,6 +133,36 @@ export const Email = () => {
               </div>
             ))}
         </CardContent>
+      </Card>
+
+      <Card className={classes.card}>
+        <form onSubmit={formik.handleSubmit}>
+          <CardHeader subheader="Add secondary emails" className={classes.cardHeader} />
+          <Divider />
+          <CardContent className={classes.cardContent}>
+            <Grid container spacing={3}>
+              <Grid item xs={12}>
+                <TextField
+                  label="Add email address"
+                  variant="outlined"
+                  fullWidth={true}
+                  id="newEmail"
+                  type="email"
+                  value={formik.values.newEmail}
+                  onChange={formik.handleChange}
+                  error={Boolean(formik.errors.newEmail && formik.touched.newEmail)}
+                  helperText={formik.touched.newEmail && formik.errors.newEmail}
+                />
+              </Grid>
+            </Grid>
+          </CardContent>
+          <Divider />
+          <CardActions className={classes.cardActions}>
+            <Button variant="contained" type="submit" disabled={formik.isSubmitting}>
+              Add email
+            </Button>
+          </CardActions>
+        </form>
       </Card>
     </AuthenticatedContainer>
   );

--- a/packages/client-password/__tests__/client-password.ts
+++ b/packages/client-password/__tests__/client-password.ts
@@ -7,6 +7,7 @@ const mockedClient = {
     resetPassword: jest.fn(),
     sendVerificationEmail: jest.fn(),
     verifyEmail: jest.fn(),
+    addEmail: jest.fn(),
     changePassword: jest.fn(),
   },
   loginWithService: jest.fn(),
@@ -100,6 +101,13 @@ describe('AccountsClientPassword', () => {
     it('should call transport', async () => {
       await accountsPassword.verifyEmail(user.email);
       expect(mockedClient.transport.verifyEmail).toHaveBeenCalledWith(user.email);
+    });
+  });
+
+  describe('addEmail', () => {
+    it('should call transport', async () => {
+      await accountsPassword.addEmail(user.email);
+      expect(mockedClient.transport.addEmail).toHaveBeenCalledWith(user.email);
     });
   });
 

--- a/packages/client-password/src/client-password.ts
+++ b/packages/client-password/src/client-password.ts
@@ -68,6 +68,14 @@ export class AccountsClientPassword {
   }
 
   /**
+   * Add an email address for a user. Must be logged in.
+   * @param {string} newEmail - A new email address for the user.
+   */
+  public addEmail(newEmail: string): Promise<void> {
+    return this.client.transport.addEmail(newEmail);
+  }
+
+  /**
    * Change the current user's password. Must be logged in.
    * @param {string} oldPassword - The user's current password.
    * @param {string} newPassword - A new password for the user.

--- a/packages/client/src/transport-interface.ts
+++ b/packages/client/src/transport-interface.ts
@@ -23,6 +23,7 @@ export interface TransportInterface {
   sendResetPasswordEmail(email: string): Promise<void>;
   sendVerificationEmail(email: string): Promise<void>;
   resetPassword(token: string, newPassword: string): Promise<LoginResult | null>;
+  addEmail(newEmail: string): Promise<void>;
   changePassword(oldPassword: string, newPassword: string): Promise<void>;
   impersonate(
     token: string,

--- a/packages/graphql-api/__tests__/modules/accounts-password/resolvers/mutation.ts
+++ b/packages/graphql-api/__tests__/modules/accounts-password/resolvers/mutation.ts
@@ -7,6 +7,7 @@ describe('accounts-password resolvers mutation', () => {
     options: {},
   };
   const accountsPasswordMock = {
+    addEmail: jest.fn(),
     changePassword: jest.fn(),
     createUser: jest.fn(),
     resetPassword: jest.fn(),
@@ -27,6 +28,22 @@ describe('accounts-password resolvers mutation', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('addEmail', () => {
+    const newEmail = 'newEmailTest';
+
+    it('should throw if no user in context', async () => {
+      await expect(Mutation.addEmail!({}, { newEmail }, {} as any, {} as any)).rejects.toThrowError(
+        'Unauthorized'
+      );
+    });
+
+    it('should call addEmail', async () => {
+      await Mutation.addEmail!({}, { newEmail }, { user, injector } as any, {} as any);
+      expect(injector.get).toHaveBeenCalledWith(AccountsPassword);
+      expect(accountsPasswordMock.addEmail).toHaveBeenCalledWith(user.id, newEmail);
+    });
   });
 
   describe('changePassword', () => {

--- a/packages/graphql-api/src/models.ts
+++ b/packages/graphql-api/src/models.ts
@@ -54,6 +54,7 @@ export type Mutation = {
   resetPassword?: Maybe<LoginResult>;
   sendVerificationEmail?: Maybe<Scalars['Boolean']>;
   sendResetPasswordEmail?: Maybe<Scalars['Boolean']>;
+  addEmail?: Maybe<Scalars['Boolean']>;
   changePassword?: Maybe<Scalars['Boolean']>;
   twoFactorSet?: Maybe<Scalars['Boolean']>;
   twoFactorUnset?: Maybe<Scalars['Boolean']>;
@@ -83,6 +84,10 @@ export type MutationSendVerificationEmailArgs = {
 
 export type MutationSendResetPasswordEmailArgs = {
   email: Scalars['String'];
+};
+
+export type MutationAddEmailArgs = {
+  newEmail: Scalars['String'];
 };
 
 export type MutationChangePasswordArgs = {
@@ -346,6 +351,12 @@ export type MutationResolvers<
     ParentType,
     ContextType,
     RequireFields<MutationSendResetPasswordEmailArgs, 'email'>
+  >;
+  addEmail?: Resolver<
+    Maybe<ResolversTypes['Boolean']>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationAddEmailArgs, 'newEmail'>
   >;
   changePassword?: Resolver<
     Maybe<ResolversTypes['Boolean']>,

--- a/packages/graphql-api/src/modules/accounts-password/resolvers/mutation.ts
+++ b/packages/graphql-api/src/modules/accounts-password/resolvers/mutation.ts
@@ -5,6 +5,15 @@ import { AccountsModuleContext } from '../../accounts';
 import { MutationResolvers } from '../../../models';
 
 export const Mutation: MutationResolvers<ModuleContext<AccountsModuleContext>> = {
+  addEmail: async (_, { newEmail }, { user, injector }) => {
+    if (!(user && user.id)) {
+      throw new Error('Unauthorized');
+    }
+
+    const userId = user.id;
+    await injector.get(AccountsPassword).addEmail(userId, newEmail);
+    return null;
+  },
   changePassword: async (_, { oldPassword, newPassword }, { user, injector }) => {
     if (!(user && user.id)) {
       throw new Error('Unauthorized');

--- a/packages/graphql-api/src/modules/accounts-password/schema/mutation.ts
+++ b/packages/graphql-api/src/modules/accounts-password/schema/mutation.ts
@@ -9,6 +9,7 @@ export default (config: AccountsPasswordModuleConfig) => gql`
     resetPassword(token: String!, newPassword: String!): LoginResult
     sendVerificationEmail(email: String!): Boolean
     sendResetPasswordEmail(email: String!): Boolean
+    addEmail(newEmail: String!): Boolean
     changePassword(oldPassword: String!, newPassword: String!): Boolean
     twoFactorSet(secret: TwoFactorSecretKeyInput!, code: String!): Boolean
     twoFactorUnset(code: String!): Boolean

--- a/packages/graphql-client/src/graphql-client.ts
+++ b/packages/graphql-client/src/graphql-client.ts
@@ -132,6 +132,13 @@ export default class GraphQLClient implements TransportInterface {
   /**
    * @inheritDoc
    */
+  public async addEmail(newEmail: string): Promise<void> {
+    return this.mutate(changePasswordMutation, 'addEmail', { newEmail });
+  }
+
+  /**
+   * @inheritDoc
+   */
   public async changePassword(oldPassword: string, newPassword: string): Promise<void> {
     return this.mutate(changePasswordMutation, 'changePassword', { oldPassword, newPassword });
   }

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -188,7 +188,7 @@ export default class AccountsPassword implements AuthenticationService {
    * Defaults to false.
    * @returns {Promise<void>} - Return a Promise.
    */
-  public addEmail(userId: string, newEmail: string, verified: boolean): Promise<void> {
+  public addEmail(userId: string, newEmail: string, verified: boolean = false): Promise<void> {
     if (!this.options.validateEmail(newEmail)) {
       throw new Error(this.options.errors.invalidEmail);
     }

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -188,7 +188,7 @@ export default class AccountsPassword implements AuthenticationService {
    * Defaults to false.
    * @returns {Promise<void>} - Return a Promise.
    */
-  public addEmail(userId: string, newEmail: string, verified: boolean = false): Promise<void> {
+  public addEmail(userId: string, newEmail: string, verified = false): Promise<void> {
     if (!this.options.validateEmail(newEmail)) {
       throw new Error(this.options.errors.invalidEmail);
     }

--- a/packages/rest-client/__tests__/rest-client.ts
+++ b/packages/rest-client/__tests__/rest-client.ts
@@ -202,6 +202,17 @@ describe('RestClient', () => {
         ));
   });
 
+  describe('addEmail', () => {
+    it('should call fetch with addEmail path', () =>
+      restClient
+        .addEmail('newEmail')
+        .then(() =>
+          expect((window.fetch as jest.Mock).mock.calls[0][0]).toBe(
+            'http://localhost:3000/accounts/password/addEmail'
+          )
+        ));
+  });
+
   describe('changePassword', () => {
     it('should call fetch with changePassword path', () =>
       restClient

--- a/packages/rest-client/src/rest-client.ts
+++ b/packages/rest-client/src/rest-client.ts
@@ -181,6 +181,16 @@ export class RestClient implements TransportInterface {
     return this.fetch('password/sendResetPasswordEmail', args, customHeaders);
   }
 
+  public addEmail(newEmail: string, customHeaders?: object): Promise<void> {
+    const args = {
+      method: 'POST',
+      body: JSON.stringify({
+        newEmail,
+      }),
+    };
+    return this.authFetch('password/addEmail', args, customHeaders);
+  }
+
   public changePassword(
     oldPassword: string,
     newPassword: string,

--- a/packages/rest-express/__tests__/endpoints/password/add-email.ts
+++ b/packages/rest-express/__tests__/endpoints/password/add-email.ts
@@ -1,0 +1,84 @@
+import { addEmail } from '../../../src/endpoints/password/add-email';
+
+const res: any = {
+  json: jest.fn(),
+  status: jest.fn(() => res),
+};
+
+describe('addEmail', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('addEmail', () => {
+    it('calls password.addEmail', async () => {
+      const passwordService = {
+        addEmail: jest.fn(() => null),
+      };
+      const accountsServer = {
+        getServices: () => ({
+          password: passwordService,
+        }),
+      };
+      const middleware = addEmail(accountsServer as any);
+
+      const req = {
+        userId: 'userId',
+        body: {
+          newEmail: 'newEmail',
+        },
+      };
+      const reqCopy = { ...req };
+
+      await middleware(req as any, res);
+
+      expect(req).toEqual(reqCopy);
+      expect(accountsServer.getServices().password.addEmail).toHaveBeenCalledWith(
+        'userId',
+        'newEmail'
+      );
+      expect(res.json).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('Sends error if no userId', async () => {
+      const middleware = addEmail(null as any);
+      await middleware({} as any, res);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalled();
+    });
+
+    it('Sends error if it was thrown on addEmail', async () => {
+      const error = { message: 'Error' };
+      const passwordService = {
+        addEmail: jest.fn(() => {
+          throw error;
+        }),
+      };
+      const accountsServer = {
+        getServices: () => ({
+          password: passwordService,
+        }),
+      };
+      const middleware = addEmail(accountsServer as any);
+      const req = {
+        userId: 'userId',
+        body: {
+          newEmail: 'newEmail',
+        },
+      };
+      const reqCopy = { ...req };
+
+      await middleware(req as any, res);
+
+      expect(req).toEqual(reqCopy);
+      expect(accountsServer.getServices().password.addEmail).toHaveBeenCalledWith(
+        'userId',
+        'newEmail'
+      );
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(error);
+    });
+  });
+});

--- a/packages/rest-express/src/endpoints/password/add-email.ts
+++ b/packages/rest-express/src/endpoints/password/add-email.ts
@@ -1,0 +1,22 @@
+import * as express from 'express';
+import { AccountsServer } from '@accounts/server';
+import { sendError } from '../../utils/send-error';
+
+export const addEmail = (accountsServer: AccountsServer) => async (
+  req: express.Request,
+  res: express.Response
+) => {
+  try {
+    if (!(req as any).userId) {
+      res.status(401);
+      res.json({ message: 'Unauthorized' });
+      return;
+    }
+    const { newEmail } = req.body;
+    const password: any = accountsServer.getServices().password;
+    await password.addEmail((req as any).userId, newEmail);
+    res.json(null);
+  } catch (err) {
+    sendError(res, err);
+  }
+};

--- a/packages/rest-express/src/express-middleware.ts
+++ b/packages/rest-express/src/express-middleware.ts
@@ -12,6 +12,7 @@ import { serviceVerifyAuthentication } from './endpoints/verify-authentication';
 import { registerPassword } from './endpoints/password/register';
 import { twoFactorSecret, twoFactorSet, twoFactorUnset } from './endpoints/password/two-factor';
 import { changePassword } from './endpoints/password/change-password';
+import { addEmail } from './endpoints/password/add-email';
 import { userLoader } from './user-loader';
 import { AccountsExpressOptions } from './types';
 
@@ -59,6 +60,8 @@ const accountsExpress = (
     router.post(`${path}/password/sendVerificationEmail`, sendVerificationEmail(accountsServer));
 
     router.post(`${path}/password/sendResetPasswordEmail`, sendResetPasswordEmail(accountsServer));
+
+    router.post(`${path}/password/addEmail`, userLoader(accountsServer), addEmail(accountsServer));
 
     router.post(
       `${path}/password/changePassword`,


### PR DESCRIPTION
Expose the accounts `addEmail` server function to be called directly from the client.
See screenshot of the example.

![localhost_3000_emails_ (3)](https://user-images.githubusercontent.com/5749437/71737729-d4c48180-2e54-11ea-805a-431c404f3b7e.png)
