### PR TITLE
refactor(server)!: unify ConnectionInformations arguments

### DIFF
--- a/packages/express-session/src/index.ts
+++ b/packages/express-session/src/index.ts
@@ -90,8 +90,7 @@ export class AccountsSession {
       const result = await this.accountsServer.refreshTokens(
         tokens.accessToken,
         tokens.refreshToken,
-        requestIp.getClientIp(req),
-        getUserAgent(req)
+        { ip: requestIp.getClientIp(req), userAgent: getUserAgent(req) }
       );
 
       this.set(req, result.tokens);

--- a/packages/graphql-api/__tests__/modules/accounts/resolvers/mutation.ts
+++ b/packages/graphql-api/__tests__/modules/accounts/resolvers/mutation.ts
@@ -69,8 +69,7 @@ describe('accounts resolvers mutation', () => {
       expect(accountsServerMock.impersonate).toHaveBeenCalledWith(
         accessToken,
         { username },
-        ip,
-        userAgent
+        { ip, userAgent }
       );
     });
   });
@@ -101,12 +100,10 @@ describe('accounts resolvers mutation', () => {
         {} as any
       );
       expect(injector.get).toHaveBeenCalledWith(AccountsServer);
-      expect(accountsServerMock.refreshTokens).toHaveBeenCalledWith(
-        accessToken,
-        refreshToken,
+      expect(accountsServerMock.refreshTokens).toHaveBeenCalledWith(accessToken, refreshToken, {
         ip,
-        userAgent
-      );
+        userAgent,
+      });
     });
   });
 });

--- a/packages/graphql-api/src/modules/accounts/resolvers/mutation.ts
+++ b/packages/graphql-api/src/modules/accounts/resolvers/mutation.ts
@@ -32,7 +32,7 @@ export const Mutation: MutationResolvers<ModuleContext<AccountsModuleContext>> =
 
     const impersonateRes = await injector
       .get(AccountsServer)
-      .impersonate(accessToken, { username }, ip, userAgent);
+      .impersonate(accessToken, { username }, { ip, userAgent });
 
     // So ctx.user can be used in subsequent queries / mutations
     if (impersonateRes && impersonateRes.user && impersonateRes.tokens) {
@@ -57,7 +57,7 @@ export const Mutation: MutationResolvers<ModuleContext<AccountsModuleContext>> =
 
     const refreshedSession = await injector
       .get(AccountsServer)
-      .refreshTokens(accessToken, refreshToken, ip, userAgent);
+      .refreshTokens(accessToken, refreshToken, { ip, userAgent });
 
     return refreshedSession;
   },

--- a/packages/rest-express/__tests__/endpoints/impersonate.ts
+++ b/packages/rest-express/__tests__/endpoints/impersonate.ts
@@ -31,7 +31,10 @@ describe('impersonate', () => {
     await middleware(req as any, res);
 
     expect(req).toEqual(reqCopy);
-    expect(accountsServer.impersonate).toHaveBeenCalledWith('token', 'toto', null, '');
+    expect(accountsServer.impersonate).toHaveBeenCalledWith('token', 'toto', {
+      ip: null,
+      userAgent: '',
+    });
     expect(res.json).toHaveBeenCalledWith(impersonateReturnType);
     expect(res.status).not.toHaveBeenCalled();
   });
@@ -56,7 +59,10 @@ describe('impersonate', () => {
     await middleware(req as any, res);
 
     expect(req).toEqual(reqCopy);
-    expect(accountsServer.impersonate).toHaveBeenCalledWith('token', 'toto', null, '');
+    expect(accountsServer.impersonate).toHaveBeenCalledWith('token', 'toto', {
+      ip: null,
+      userAgent: '',
+    });
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.json).toHaveBeenCalledWith(error);
   });

--- a/packages/rest-express/__tests__/endpoints/refresh-access-token.ts
+++ b/packages/rest-express/__tests__/endpoints/refresh-access-token.ts
@@ -32,7 +32,10 @@ describe('refreshAccessToken', () => {
 
     await middleware(req as any, res);
 
-    expect(accountsServer.refreshTokens).toHaveBeenCalledWith('token', 'refresh', null, '');
+    expect(accountsServer.refreshTokens).toHaveBeenCalledWith('token', 'refresh', {
+      ip: null,
+      userAgent: '',
+    });
     expect(req).toEqual(reqCopy);
     expect(res.json).toHaveBeenCalledWith(session);
     expect(res.status).not.toHaveBeenCalled();
@@ -58,7 +61,10 @@ describe('refreshAccessToken', () => {
     await middleware(req as any, res);
 
     expect(req).toEqual(reqCopy);
-    expect(accountsServer.refreshTokens).toHaveBeenCalledWith('token', 'refresh', null, '');
+    expect(accountsServer.refreshTokens).toHaveBeenCalledWith('token', 'refresh', {
+      ip: null,
+      userAgent: '',
+    });
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.json).toHaveBeenCalledWith(error);
   });

--- a/packages/rest-express/src/endpoints/impersonate.ts
+++ b/packages/rest-express/src/endpoints/impersonate.ts
@@ -19,12 +19,10 @@ export const impersonate = (accountsServer: AccountsServer) => async (
     } = req.body;
     const userAgent = getUserAgent(req);
     const ip = requestIp.getClientIp(req);
-    const impersonateRes = await accountsServer.impersonate(
-      accessToken,
-      impersonated,
+    const impersonateRes = await accountsServer.impersonate(accessToken, impersonated, {
       ip,
-      userAgent
-    );
+      userAgent,
+    });
     res.json(impersonateRes);
   } catch (err) {
     sendError(res, err);

--- a/packages/rest-express/src/endpoints/refresh-access-token.ts
+++ b/packages/rest-express/src/endpoints/refresh-access-token.ts
@@ -12,12 +12,10 @@ export const refreshAccessToken = (accountsServer: AccountsServer) => async (
     const { accessToken, refreshToken } = req.body;
     const userAgent = getUserAgent(req);
     const ip = requestIp.getClientIp(req);
-    const refreshedSession = await accountsServer.refreshTokens(
-      accessToken,
-      refreshToken,
+    const refreshedSession = await accountsServer.refreshTokens(accessToken, refreshToken, {
       ip,
-      userAgent
-    );
+      userAgent,
+    });
     res.json(refreshedSession);
   } catch (err) {
     sendError(res, err);

--- a/packages/server/__tests__/account-server.ts
+++ b/packages/server/__tests__/account-server.ts
@@ -433,7 +433,10 @@ describe('AccountsServer', () => {
           token: '456',
           userId: 'userId',
         });
-        await accountsServer.refreshTokens(accessToken, refreshToken, 'ip', 'userAgent');
+        await accountsServer.refreshTokens(accessToken, refreshToken, {
+          ip: 'ip',
+          userAgent: 'userAgent',
+        });
       } catch (err) {
         // nothing to do
       }
@@ -474,7 +477,10 @@ describe('AccountsServer', () => {
         refreshToken: 'newRefreshToken',
       });
 
-      await accountsServer.refreshTokens(accessToken, refreshToken, 'ip', 'user agent');
+      await accountsServer.refreshTokens(accessToken, refreshToken, {
+        ip: 'ip',
+        userAgent: 'userAgent',
+      });
       await delay(10);
       expect(hookSpy).toHaveBeenCalled();
     });
@@ -493,7 +499,10 @@ describe('AccountsServer', () => {
       try {
         const accessToken = null as any;
         const impersonated = null as any;
-        await accountsServer.impersonate(accessToken, impersonated, 'ip', 'user agent');
+        await accountsServer.impersonate(accessToken, impersonated, {
+          ip: 'ip',
+          userAgent: 'userAgent',
+        });
       } catch (err) {
         // nothing to do
       }
@@ -535,7 +544,14 @@ describe('AccountsServer', () => {
           userId,
         } as any);
 
-      await accountsServer.impersonate(accessToken, { userId: 'userId' }, 'ip', 'user agent');
+      await accountsServer.impersonate(
+        accessToken,
+        { userId: 'userId' },
+        {
+          ip: 'ip',
+          userAgent: 'userAgent',
+        }
+      );
       await delay(10);
       expect(hookSpy).toHaveBeenCalled();
     });
@@ -572,7 +588,10 @@ describe('AccountsServer', () => {
         accessToken: 'newAccessToken',
         refreshToken: 'newRefreshToken',
       });
-      const res = await accountsServer.refreshTokens(accessToken, refreshToken, 'ip', 'user agent');
+      const res = await accountsServer.refreshTokens(accessToken, refreshToken, {
+        ip: 'ip',
+        userAgent: 'userAgent',
+      });
       expect(updateSession.mock.calls[0]).toEqual([
         '456',
         { ip: 'ip', userAgent: 'user agent' },
@@ -621,7 +640,10 @@ describe('AccountsServer', () => {
         refreshToken: 'newRefreshToken',
       });
 
-      const res = await accountsServer.refreshTokens(accessToken, refreshToken, 'ip', 'user agent');
+      const res = await accountsServer.refreshTokens(accessToken, refreshToken, {
+        ip: 'ip',
+        userAgent: 'userAgent',
+      });
       expect(updateSession.mock.calls[0]).toEqual([
         '456',
         { ip: 'ip', userAgent: 'user agent' },
@@ -642,7 +664,10 @@ describe('AccountsServer', () => {
         {}
       );
       await expect(
-        accountsServer.refreshTokens(null as any, null as any, 'ip', 'user agent')
+        accountsServer.refreshTokens(null as any, null as any, {
+          ip: 'ip',
+          userAgent: 'userAgent',
+        })
       ).rejects.toThrowError('An accessToken and refreshToken are required');
     });
     it('throws error if tokens are not valid', async () => {
@@ -654,7 +679,10 @@ describe('AccountsServer', () => {
         {}
       );
       await expect(
-        accountsServer.refreshTokens('bad access token', 'bad refresh token', 'ip', 'user agent')
+        accountsServer.refreshTokens('bad access token', 'bad refresh token', {
+          ip: 'ip',
+          userAgent: 'userAgent',
+        })
       ).rejects.toThrowError('Tokens are not valid');
     });
 
@@ -673,7 +701,10 @@ describe('AccountsServer', () => {
         userId: '213',
       });
       await expect(
-        accountsServer.refreshTokens(accessToken, refreshToken, 'ip', 'user agent')
+        accountsServer.refreshTokens(accessToken, refreshToken, {
+          ip: 'ip',
+          userAgent: 'userAgent',
+        })
       ).rejects.toThrowError('Session not found');
     });
 
@@ -695,7 +726,10 @@ describe('AccountsServer', () => {
         userId: 'user',
       });
       await expect(
-        accountsServer.refreshTokens(accessToken, refreshToken, 'ip', 'user agent')
+        accountsServer.refreshTokens(accessToken, refreshToken, {
+          ip: 'ip',
+          userAgent: 'userAgent',
+        })
       ).rejects.toThrowError('Session is no longer valid');
     });
 
@@ -721,7 +755,10 @@ describe('AccountsServer', () => {
         userId: 'user',
       });
       await expect(
-        accountsServer.refreshTokens(accessToken, refreshToken, 'ip', 'user agent')
+        accountsServer.refreshTokens(accessToken, refreshToken, {
+          ip: 'ip',
+          userAgent: 'userAgent',
+        })
       ).rejects.toThrowError('User not found');
     });
   });
@@ -935,7 +972,10 @@ describe('AccountsServer', () => {
       const accessToken = null as any;
       const impersonated = null as any;
       await expect(
-        accountsServer.impersonate(accessToken, impersonated, 'ip', 'user agent')
+        accountsServer.impersonate(accessToken, impersonated, {
+          ip: 'ip',
+          userAgent: 'userAgent',
+        })
       ).rejects.toThrowError('An access token is required');
     });
 
@@ -949,7 +989,14 @@ describe('AccountsServer', () => {
       );
 
       await expect(
-        accountsServer.impersonate('invalidToken', {}, 'ip', 'user agent')
+        accountsServer.impersonate(
+          'invalidToken',
+          {},
+          {
+            ip: 'ip',
+            userAgent: 'userAgent',
+          }
+        )
       ).rejects.toThrowError('Access token is not valid');
     });
 
@@ -970,7 +1017,14 @@ describe('AccountsServer', () => {
         } as any);
 
       await expect(
-        accountsServer.impersonate(accessToken, {}, 'ip', 'user agent')
+        accountsServer.impersonate(
+          accessToken,
+          {},
+          {
+            ip: 'ip',
+            userAgent: 'userAgent',
+          }
+        )
       ).rejects.toThrowError('Session is not valid for user');
     });
 
@@ -993,7 +1047,14 @@ describe('AccountsServer', () => {
         } as any);
 
       await expect(
-        accountsServer.impersonate(accessToken, { userId: 'userId' }, 'ip', 'user agent')
+        accountsServer.impersonate(
+          accessToken,
+          { userId: 'userId' },
+          {
+            ip: 'ip',
+            userAgent: 'userAgent',
+          }
+        )
       ).rejects.toThrowError('User not found');
     });
 
@@ -1020,7 +1081,14 @@ describe('AccountsServer', () => {
         } as any);
 
       await expect(
-        accountsServer.impersonate(accessToken, { userId: 'userId' }, 'ip', 'user agent')
+        accountsServer.impersonate(
+          accessToken,
+          { userId: 'userId' },
+          {
+            ip: 'ip',
+            userAgent: 'userAgent',
+          }
+        )
       ).rejects.toThrowError('Impersonated user not found');
     });
 
@@ -1046,8 +1114,10 @@ describe('AccountsServer', () => {
       const res = await accountsServer.impersonate(
         accessToken,
         { userId: 'userId' },
-        'ip',
-        'user agent'
+        {
+          ip: 'ip',
+          userAgent: 'userAgent',
+        }
       );
       expect(res.authorized).toEqual(false);
     });
@@ -1080,8 +1150,10 @@ describe('AccountsServer', () => {
       const res = await accountsServer.impersonate(
         accessToken,
         { userId: 'userId' },
-        'ip',
-        'user agent'
+        {
+          ip: 'ip',
+          userAgent: 'userAgent',
+        }
       );
       expect(res.authorized).toEqual(false);
     });
@@ -1119,8 +1191,10 @@ describe('AccountsServer', () => {
       const res = await accountsServer.impersonate(
         accessToken,
         { userId: 'userId' },
-        'ip',
-        'user agent'
+        {
+          ip: 'ip',
+          userAgent: 'userAgent',
+        }
       );
       expect(res).toEqual({
         authorized: true,

--- a/packages/server/__tests__/account-server.ts
+++ b/packages/server/__tests__/account-server.ts
@@ -594,12 +594,15 @@ describe('AccountsServer', () => {
       });
       expect(updateSession.mock.calls[0]).toEqual([
         '456',
-        { ip: 'ip', userAgent: 'user agent' },
+        { ip: 'ip', userAgent: 'userAgent' },
         undefined,
       ]);
-      expect((res as any).user).toEqual({
-        userId: '123',
-        username: 'username',
+      expect(res).toEqual({
+        sessionId: '456',
+        tokens: {
+          accessToken: 'newAccessToken',
+          refreshToken: 'newRefreshToken',
+        },
       });
     });
 
@@ -646,12 +649,15 @@ describe('AccountsServer', () => {
       });
       expect(updateSession.mock.calls[0]).toEqual([
         '456',
-        { ip: 'ip', userAgent: 'user agent' },
+        { ip: 'ip', userAgent: 'userAgent' },
         '123',
       ]);
-      expect((res as any).user).toEqual({
-        userId: '123',
-        username: 'username',
+      expect(res).toEqual({
+        sessionId: '456',
+        tokens: {
+          accessToken: 'newAccessToken',
+          refreshToken: 'newRefreshToken',
+        },
       });
     });
 
@@ -1204,7 +1210,7 @@ describe('AccountsServer', () => {
       expect(createSession).toHaveBeenCalledWith(
         expect.any(String),
         expect.any(String),
-        { ip: 'ip', userAgent: 'user agent' },
+        { ip: 'ip', userAgent: 'userAgent' },
         {
           impersonatorUserId: user.id,
         }


### PR DESCRIPTION
## ⚠️ Breaking change

**This will be a breaking change for you only if you call these server functions directly in your code** if you just call these functions from the client you don't have to change anything.

### server.refreshTokens

```js
// Before
refreshTokens(accessToken: string, refreshToken: string, ip: string, userAgent: string)
// After
refreshTokens(accessToken: string, refreshToken: string, infos: ConnectionInformations)
```

### server.impersonate

```js
// Before
impersonate(accessToken: string, impersonated: object, ip: string, userAgent: string)
// After
impersonate(accessToken: string, impersonated: object, infos: ConnectionInformations)
```