### PR TITLE
chore(graphql-client): name the getUser mutation

### DIFF
--- a/packages/graphql-client/src/graphql/get-user.query.ts
+++ b/packages/graphql-client/src/graphql/get-user.query.ts
@@ -2,7 +2,7 @@ import gql from 'graphql-tag';
 
 export const getUserQuery = (userFieldsFragment: any) => gql`
   ${userFieldsFragment}
-  query {
+  query getUser {
     getUser {
       ...userFields
     }


### PR DESCRIPTION
Hey!

This change is for readability on graphql loggers and also for conditional apollo links that rely on operation names.
I would love to see this merged quickly as it does not break anything.

Thanks!
