### PR TITLE
fix!: fix client password types

### DIFF
--- a/packages/client-password/__tests__/client-password.ts
+++ b/packages/client-password/__tests__/client-password.ts
@@ -60,7 +60,7 @@ describe('AccountsClientPassword', () => {
 
   describe('login', () => {
     it('should hash password and call client', async () => {
-      await accountsPassword.login(user);
+      await accountsPassword.login(user as any);
       expect(accountsPassword.hashPassword).toHaveBeenCalledTimes(1);
       expect(accountsPassword.hashPassword).toHaveBeenCalledWith(user.password);
       expect(mockedClient.loginWithService).toHaveBeenCalledTimes(1);

--- a/packages/client-password/src/client-password.ts
+++ b/packages/client-password/src/client-password.ts
@@ -1,5 +1,5 @@
 import { AccountsClient } from '@accounts/client';
-import { LoginResult, CreateUser } from '@accounts/types';
+import { LoginResult, CreateUserServicePassword } from '@accounts/types';
 import { AccountsClientPasswordOptions } from './types';
 
 export class AccountsClientPassword {
@@ -17,7 +17,7 @@ export class AccountsClientPassword {
   /**
    * Create a new user.
    */
-  public async createUser(user: CreateUser): Promise<string> {
+  public async createUser(user: CreateUserServicePassword): Promise<string> {
     const hashedPassword = this.hashPassword(user.password);
     return this.client.transport.createUser({ ...user, password: hashedPassword });
   }

--- a/packages/client-password/src/client-password.ts
+++ b/packages/client-password/src/client-password.ts
@@ -1,5 +1,5 @@
 import { AccountsClient } from '@accounts/client';
-import { LoginResult, CreateUserServicePassword } from '@accounts/types';
+import { LoginResult, CreateUserServicePassword, LoginUserPasswordService } from '@accounts/types';
 import { AccountsClientPasswordOptions } from './types';
 
 export class AccountsClientPassword {
@@ -25,8 +25,8 @@ export class AccountsClientPassword {
   /**
    * Log the user in with a password.
    */
-  public async login(user: any): Promise<LoginResult> {
-    const hashedPassword = this.hashPassword(user.password);
+  public async login(user: LoginUserPasswordService): Promise<LoginResult> {
+    const hashedPassword = this.hashPassword(user.password as string);
     return this.client.loginWithService('password', {
       ...user,
       password: hashedPassword,

--- a/packages/graphql-api/src/modules/accounts-password/resolvers/mutation.ts
+++ b/packages/graphql-api/src/modules/accounts-password/resolvers/mutation.ts
@@ -1,5 +1,6 @@
 import { ModuleContext } from '@graphql-modules/core';
-import { AccountsPassword, PasswordCreateUserType } from '@accounts/password';
+import { CreateUserServicePassword } from '@accounts/types';
+import { AccountsPassword } from '@accounts/password';
 import { AccountsServer } from '@accounts/server';
 import { AccountsModuleContext } from '../../accounts';
 import { MutationResolvers } from '../../../models';
@@ -24,7 +25,9 @@ export const Mutation: MutationResolvers<ModuleContext<AccountsModuleContext>> =
     return null;
   },
   createUser: async (_, { user }, { injector }) => {
-    const userId = await injector.get(AccountsPassword).createUser(user as PasswordCreateUserType);
+    const userId = await injector
+      .get(AccountsPassword)
+      .createUser(user as CreateUserServicePassword);
     return injector.get(AccountsServer).options.ambiguousErrorMessages ? null : userId;
   },
   twoFactorSet: async (_, { code, secret }, { user, injector }) => {

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -10,6 +10,8 @@ import {
   ConnectionInformations,
   LoginResult,
   CreateUserServicePassword,
+  PasswordType,
+  LoginUserPasswordService,
 } from '@accounts/types';
 import { TwoFactor, AccountsTwoFactorOptions, getUserTwoFactorService } from '@accounts/two-factor';
 import { AccountsServer, ServerHooks, generateRandomToken } from '@accounts/server';
@@ -21,7 +23,7 @@ import {
   verifyPassword,
   isEmail,
 } from './utils';
-import { PasswordLoginType, PasswordType, ErrorMessages } from './types';
+import { ErrorMessages } from './types';
 import { errors } from './errors';
 
 export interface AccountsPasswordOptions {
@@ -142,7 +144,7 @@ export default class AccountsPassword implements AuthenticationService {
     this.twoFactor.setStore(store);
   }
 
-  public async authenticate(params: PasswordLoginType): Promise<User> {
+  public async authenticate(params: LoginUserPasswordService): Promise<User> {
     const { user, password, code } = params;
     if (!user || !password) {
       throw new Error(this.options.errors.unrecognizedOptionsForLogin);

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -9,6 +9,7 @@ import {
   HashAlgorithm,
   ConnectionInformations,
   LoginResult,
+  CreateUserServicePassword,
 } from '@accounts/types';
 import { TwoFactor, AccountsTwoFactorOptions, getUserTwoFactorService } from '@accounts/two-factor';
 import { AccountsServer, ServerHooks, generateRandomToken } from '@accounts/server';
@@ -20,7 +21,7 @@ import {
   verifyPassword,
   isEmail,
 } from './utils';
-import { PasswordCreateUserType, PasswordLoginType, PasswordType, ErrorMessages } from './types';
+import { PasswordLoginType, PasswordType, ErrorMessages } from './types';
 import { errors } from './errors';
 
 export interface AccountsPasswordOptions {
@@ -79,8 +80,8 @@ export interface AccountsPasswordOptions {
    * By default we only allow `username`, `email` and `password` fields.
    */
   validateNewUser?: (
-    user: PasswordCreateUserType
-  ) => Promise<PasswordCreateUserType> | PasswordCreateUserType;
+    user: CreateUserServicePassword
+  ) => Promise<CreateUserServicePassword> | CreateUserServicePassword;
   /**
    * Function that check if the email is a valid email.
    * This function will be called when you call `createUser` and `addEmail`.
@@ -496,7 +497,7 @@ export default class AccountsPassword implements AuthenticationService {
    * @param user - The user object.
    * @returns Return the id of user created.
    */
-  public async createUser(user: PasswordCreateUserType): Promise<string> {
+  public async createUser(user: CreateUserServicePassword): Promise<string> {
     if (!user.username && !user.email) {
       throw new Error(this.options.errors.usernameOrEmailRequired);
     }
@@ -527,7 +528,7 @@ export default class AccountsPassword implements AuthenticationService {
     // If user does not provide the validate function only allow some fields
     user = this.options.validateNewUser
       ? await this.options.validateNewUser(user)
-      : pick<PasswordCreateUserType, 'username' | 'email' | 'password'>(user, [
+      : pick<CreateUserServicePassword, 'username' | 'email' | 'password'>(user, [
           'username',
           'email',
           'password',

--- a/packages/password/src/types/index.ts
+++ b/packages/password/src/types/index.ts
@@ -1,3 +1,1 @@
-export { PasswordLoginType } from './password-login-type';
-export { PasswordType } from './password-type';
 export { ErrorMessages } from './error-messages';

--- a/packages/password/src/types/index.ts
+++ b/packages/password/src/types/index.ts
@@ -1,4 +1,3 @@
-export { PasswordCreateUserType } from './password-create-user-type';
 export { PasswordLoginType } from './password-login-type';
 export { PasswordType } from './password-type';
 export { ErrorMessages } from './error-messages';

--- a/packages/password/src/types/password-create-user-type.ts
+++ b/packages/password/src/types/password-create-user-type.ts
@@ -1,6 +1,0 @@
-import { CreateUser } from '@accounts/types';
-import { PasswordType } from './password-type';
-
-export interface PasswordCreateUserType extends CreateUser {
-  password: PasswordType;
-}

--- a/packages/password/src/utils/encryption.ts
+++ b/packages/password/src/utils/encryption.ts
@@ -1,6 +1,6 @@
 import * as bcrypt from 'bcryptjs';
 import { createHash } from 'crypto';
-import { PasswordType } from '../types/password-type';
+import { PasswordType } from '@accounts/types';
 
 export const bcryptPassword = async (password: string): Promise<string> => {
   const salt = await bcrypt.genSalt(10);

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -15,3 +15,5 @@ export * from './types/session/database-interface';
 export * from './types/session/session';
 export * from './types/services/password/create-user';
 export * from './types/services/password/database-interface';
+export * from './types/services/password/login-user';
+export * from './types/services/password/password-type';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -13,4 +13,5 @@ export * from './types/authentication-service';
 export * from './types/hash-algorithm';
 export * from './types/session/database-interface';
 export * from './types/session/session';
+export * from './types/services/password/create-user';
 export * from './types/services/password/database-interface';

--- a/packages/types/src/types/services/password/create-user.ts
+++ b/packages/types/src/types/services/password/create-user.ts
@@ -1,0 +1,7 @@
+import { CreateUser } from '../../create-user';
+
+export interface CreateUserServicePassword extends CreateUser {
+  username?: string;
+  email?: string;
+  password: string;
+}

--- a/packages/types/src/types/services/password/login-user.ts
+++ b/packages/types/src/types/services/password/login-user.ts
@@ -1,7 +1,7 @@
-import { LoginUserIdentity } from '@accounts/types';
+import { LoginUserIdentity } from '../../login-user-identity';
 import { PasswordType } from './password-type';
 
-export interface PasswordLoginType {
+export interface LoginUserPasswordService {
   user: string | LoginUserIdentity;
   password: PasswordType;
   // 2FA code

--- a/packages/types/src/types/services/password/password-type.ts
+++ b/packages/types/src/types/services/password/password-type.ts
@@ -1,4 +1,4 @@
-import { HashAlgorithm } from '@accounts/types';
+import { HashAlgorithm } from '../../hash-algorithm';
 
 export type PasswordType =
   | string


### PR DESCRIPTION
Close #818 #825 

## ⚠️ breaking changes

- `PasswordCreateUserType` has been renamed to `CreateUserServicePassword` and is now exported from `@accounts/types`
- `PasswordLoginType` as been renamed to `LoginUserPasswordService` and is now exported from `@accounts/types`
- `PasswordType` is now exported from `@accounts/types`