### PR TITLE
chore(password)!: password from should always be a string, not P…

### DIFF
--- a/packages/password/__tests__/utils/encryption.ts
+++ b/packages/password/__tests__/utils/encryption.ts
@@ -13,11 +13,6 @@ describe('encryption', () => {
       const password = 'pass';
       expect(hashPassword(password, 'sha256')).not.toBe(password);
     });
-
-    it('should return the digest password', () => {
-      const password = { digest: 'pass' };
-      expect(hashPassword(password as any, 'sha256')).toBe(password.digest);
-    });
   });
 
   describe('verifyPassword', () => {

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -10,7 +10,6 @@ import {
   ConnectionInformations,
   LoginResult,
   CreateUserServicePassword,
-  PasswordType,
   LoginUserPasswordService,
 } from '@accounts/types';
 import { TwoFactor, AccountsTwoFactorOptions, getUserTwoFactorService } from '@accounts/two-factor';
@@ -93,7 +92,7 @@ export interface AccountsPasswordOptions {
    * Function that check if the password is valid.
    * This function will be called when you call `createUser` and `changePassword`.
    */
-  validatePassword?: (password?: PasswordType) => boolean;
+  validatePassword?: (password?: string) => boolean;
   /**
    * Function that check if the username is a valid username.
    * This function will be called when you call `createUser`.
@@ -115,7 +114,7 @@ const defaultOptions = {
   validateEmail(email?: string): boolean {
     return !isEmpty(trim(email)) && isEmail(email);
   },
-  validatePassword(password?: PasswordType): boolean {
+  validatePassword(password?: string): boolean {
     return !isEmpty(password);
   },
   validateUsername(username?: string): boolean {
@@ -245,7 +244,7 @@ export default class AccountsPassword implements AuthenticationService {
    */
   public async resetPassword(
     token: string,
-    newPassword: PasswordType,
+    newPassword: string,
     infos: ConnectionInformations
   ): Promise<LoginResult | null> {
     if (!token || !isString(token)) {
@@ -560,7 +559,7 @@ export default class AccountsPassword implements AuthenticationService {
 
   private async passwordAuthenticator(
     user: string | LoginUserIdentity,
-    password: PasswordType
+    password: string
   ): Promise<User> {
     const { username, email, id } = isString(user)
       ? this.toUsernameAndEmail({ user })
@@ -607,9 +606,9 @@ export default class AccountsPassword implements AuthenticationService {
     return foundUser;
   }
 
-  private async hashAndBcryptPassword(password: PasswordType): Promise<string> {
+  private async hashAndBcryptPassword(password: string): Promise<string> {
     const hashAlgorithm = this.options.passwordHashAlgorithm;
-    const hashedPassword: any = hashAlgorithm ? hashPassword(password, hashAlgorithm) : password;
+    const hashedPassword = hashAlgorithm ? hashPassword(password, hashAlgorithm) : password;
     return bcryptPassword(hashedPassword);
   }
 

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -30,6 +30,9 @@ export interface AccountsPasswordOptions {
    * Two factor options passed down to the @accounts/two-factor service.
    */
   twoFactor?: AccountsTwoFactorOptions;
+  /**
+   * Set an hash algorithm for the password to be encrypted server side.
+   */
   passwordHashAlgorithm?: HashAlgorithm;
   /**
    * The number of milliseconds from when a link to verify the user email is sent until token expires and user can't verify his email with the link anymore.

--- a/packages/password/src/utils/encryption.ts
+++ b/packages/password/src/utils/encryption.ts
@@ -1,6 +1,5 @@
 import * as bcrypt from 'bcryptjs';
 import { createHash } from 'crypto';
-import { PasswordType } from '@accounts/types';
 
 export const bcryptPassword = async (password: string): Promise<string> => {
   const salt = await bcrypt.genSalt(10);
@@ -8,14 +7,10 @@ export const bcryptPassword = async (password: string): Promise<string> => {
   return hash;
 };
 
-export const hashPassword = (password: PasswordType, algorithm: string) => {
-  if (typeof password === 'string') {
-    const hash = createHash(algorithm);
-    hash.update(password);
-    return hash.digest('hex');
-  }
-
-  return password.digest;
+export const hashPassword = (password: string, algorithm: string) => {
+  const hash = createHash(algorithm);
+  hash.update(password);
+  return hash.digest('hex');
 };
 
 export const verifyPassword = async (password: string, hash: string): Promise<boolean> =>

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -16,4 +16,3 @@ export * from './types/session/session';
 export * from './types/services/password/create-user';
 export * from './types/services/password/database-interface';
 export * from './types/services/password/login-user';
-export * from './types/services/password/password-type';

--- a/packages/types/src/types/services/password/login-user.ts
+++ b/packages/types/src/types/services/password/login-user.ts
@@ -1,9 +1,8 @@
 import { LoginUserIdentity } from '../../login-user-identity';
-import { PasswordType } from './password-type';
 
 export interface LoginUserPasswordService {
   user: string | LoginUserIdentity;
-  password: PasswordType;
+  password: string;
   // 2FA code
   code?: string;
 }

--- a/packages/types/src/types/services/password/password-type.ts
+++ b/packages/types/src/types/services/password/password-type.ts
@@ -1,8 +1,0 @@
-import { HashAlgorithm } from '../../hash-algorithm';
-
-export type PasswordType =
-  | string
-  | {
-      digest: string;
-      algorithm: HashAlgorithm;
-    };


### PR DESCRIPTION
## ⚠️ Breaking change

- remove `PasswordType`
- password should be sent as a string instead of `string | PasswordType`

GraphQL was only using strings password, so only REST users might be affected by this change.