### PR TITLE
feat(password)!: add custom password hashing option

### DIFF
--- a/packages/password/__tests__/utils/encryption.ts
+++ b/packages/password/__tests__/utils/encryption.ts
@@ -1,17 +1,10 @@
-import { bcryptPassword, hashPassword, verifyPassword } from '../../src/utils/encryption';
+import { bcryptPassword, verifyPassword } from '../../src/utils/encryption';
 
 describe('encryption', () => {
   describe('bcryptPassword', () => {
     it('should return the hashed password', () => {
       const password = 'pass';
       expect(bcryptPassword(password)).not.toBe(password);
-    });
-  });
-
-  describe('hashPassword', () => {
-    it('should return the hashed password', () => {
-      const password = 'pass';
-      expect(hashPassword(password, 'sha256')).not.toBe(password);
     });
   });
 

--- a/packages/password/src/utils/encryption.ts
+++ b/packages/password/src/utils/encryption.ts
@@ -1,17 +1,10 @@
-import * as bcrypt from 'bcryptjs';
-import { createHash } from 'crypto';
+import { genSalt, hash, compare } from 'bcryptjs';
 
 export const bcryptPassword = async (password: string): Promise<string> => {
-  const salt = await bcrypt.genSalt(10);
-  const hash = await bcrypt.hash(password, salt);
-  return hash;
-};
-
-export const hashPassword = (password: string, algorithm: string) => {
-  const hash = createHash(algorithm);
-  hash.update(password);
-  return hash.digest('hex');
+  const salt = await genSalt(10);
+  const hashedPassword = await hash(password, salt);
+  return hashedPassword;
 };
 
 export const verifyPassword = async (password: string, hash: string): Promise<boolean> =>
-  bcrypt.compare(password, hash);
+  compare(password, hash);

--- a/packages/password/src/utils/index.ts
+++ b/packages/password/src/utils/index.ts
@@ -1,3 +1,3 @@
 export { getUserResetTokens, getUserVerificationTokens } from './user';
-export { hashPassword, bcryptPassword, verifyPassword } from './encryption';
+export { bcryptPassword, verifyPassword } from './encryption';
 export { isEmail } from './is-email';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -10,7 +10,6 @@ export * from './types/impersonation-result';
 export * from './types/login-user-identity';
 export * from './types/hook-listener';
 export * from './types/authentication-service';
-export * from './types/hash-algorithm';
 export * from './types/session/database-interface';
 export * from './types/session/session';
 export * from './types/services/password/create-user';

--- a/packages/types/src/types/hash-algorithm.ts
+++ b/packages/types/src/types/hash-algorithm.ts
@@ -1,9 +1,0 @@
-export type HashAlgorithm =
-  | 'sha'
-  | 'sha1'
-  | 'sha224'
-  | 'sha256'
-  | 'sha384'
-  | 'sha512'
-  | 'md5'
-  | 'ripemd160';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3356,20 +3356,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@12.12.7", "@types/node@>= 8", "@types/node@>=6":
+"@types/node@*", "@types/node@12.12.14", "@types/node@12.12.7", "@types/node@>= 8", "@types/node@>=6", "@types/node@^10.1.0":
   version "12.12.7"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.7.tgz#01e4ea724d9e3bd50d90c11fd5980ba317d8fa11"
   integrity sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w==
-
-"@types/node@12.12.14":
-  version "12.12.14"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.14.tgz#1c1d6e3c75dba466e0326948d56e8bd72a1903d2"
-  integrity sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==
-
-"@types/node@^10.1.0":
-  version "10.17.15"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.15.tgz#bfff4e23e9e70be6eec450419d51e18de1daf8e7"
-  integrity sha512-daFGV9GSs6USfPgxceDA8nlSe48XrVCJfDeYm7eokxq/ye7iuOH87hKXgMtEAVLFapkczbZsx868PMDT1Y0a6A==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
Close #811 

You can now customise the hashing and verification of the password.
By default we use bcrypt to hash the password. We now provide the following 2 options:
- `hashPassword?: (password: string) => Promise<string>;` 
- `verifyPassword?: (password: string, hash: string) => Promise<boolean>;`

If you want to use `argon2` for example you can do the following:

```js
const argon2 = require('argon2');

const passwordOptions = {
  hashPassword: (password) => argon2.hash("password"),
  verifyPassword: (password, hash) => argon2.verify(hash, password),
};
```

## ⚠️ Breaking changes

- remove the `passwordHashAlgorithm` option. You can have the same behavior as before by providing the new `hashPassword` option.