### PR TITLE
feat(password): use custom error

### DIFF
--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -62,6 +62,11 @@ enum ResetPasswordErrors {
   NoEmailSet = 'NoEmailSet',
 }
 
+enum ChangePasswordErrors {
+  InvalidPassword = 'InvalidPassword',
+  NoEmailSet = 'NoEmailSet',
+}
+
 export interface AccountsPasswordOptions {
   /**
    * Two factor options passed down to the @accounts/two-factor service.
@@ -433,7 +438,10 @@ export default class AccountsPassword implements AuthenticationService {
     newPassword: string
   ): Promise<void> {
     if (!this.options.validatePassword(newPassword)) {
-      throw new AccountsJsError(this.options.errors.invalidPassword, `InvalidPassword`);
+      throw new AccountsJsError(
+        this.options.errors.invalidPassword,
+        ChangePasswordErrors.InvalidPassword
+      );
     }
 
     const user = await this.passwordAuthenticator({ id: userId }, oldPassword);
@@ -450,7 +458,7 @@ export default class AccountsPassword implements AuthenticationService {
     if (this.options.notifyUserAfterPasswordChanged) {
       const address = user.emails && user.emails[0].address;
       if (!address) {
-        throw new AccountsJsError(this.options.errors.noEmailSet, `NoEmailSet`);
+        throw new AccountsJsError(this.options.errors.noEmailSet, ChangePasswordErrors.NoEmailSet);
       }
 
       const passwordChangedMail = this.server.prepareMail(

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -72,6 +72,11 @@ enum SendVerificationEmailErrors {
   UserNotFound = 'UserNotFound',
 }
 
+enum SendResetPasswordEmailErrors {
+  InvalidEmail = 'InvalidEmail',
+  UserNotFound = 'UserNotFound',
+}
+
 export interface AccountsPasswordOptions {
   /**
    * Two factor options passed down to the @accounts/two-factor service.
@@ -545,7 +550,10 @@ export default class AccountsPassword implements AuthenticationService {
    */
   public async sendResetPasswordEmail(address: string): Promise<void> {
     if (!address || !isString(address)) {
-      throw new AccountsJsError(this.options.errors.invalidEmail, `InvalidEmail`);
+      throw new AccountsJsError(
+        this.options.errors.invalidEmail,
+        SendResetPasswordEmailErrors.InvalidEmail
+      );
     }
 
     const user = await this.db.findUserByEmail(address);
@@ -554,7 +562,10 @@ export default class AccountsPassword implements AuthenticationService {
       if (this.server.options.ambiguousErrorMessages) {
         return;
       }
-      throw new AccountsJsError(this.options.errors.userNotFound, `UserNotFound`);
+      throw new AccountsJsError(
+        this.options.errors.userNotFound,
+        SendResetPasswordEmailErrors.UserNotFound
+      );
     }
     const token = generateRandomToken();
     await this.db.addResetPasswordToken(user.id, address, token, 'reset');

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -395,9 +395,7 @@ export default class AccountsPassword implements AuthenticationService {
    * @param {string} oldPassword - The user's current password.
    * @param {string} newPassword - A new password for the user.
    * @returns {Promise<void>} - Return a Promise.
-   *
-   * @throws {InvalidPassword} Password validation via option `validatePassword` failed.
-   * @throws {NoEmailSet} User has no email set.
+   * @throws {@link ChangePasswordErrors}
    */
   public async changePassword(
     userId: string,

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -242,10 +242,7 @@ export default class AccountsPassword implements AuthenticationService {
    * @description Marks the user's email address as verified.
    * @param {string} token - The token retrieved from the verification URL.
    * @returns {Promise<void>} - Return a Promise.
-   *
-   * @throws {InvalidToken} Will throw if token validation failed.
-   * @throws {VerifyEmailLinkExpired} The token does not exist or is expired.
-   * @throws {VerifyEmailLinkUnknownAddress} The token is valid but no email address found for the entry.
+   * @throws {@link VerifyEmailErrors}
    */
   public async verifyEmail(token: string): Promise<void> {
     if (!token || !isString(token)) {

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -441,10 +441,13 @@ export default class AccountsPassword implements AuthenticationService {
    * Defaults to the first unverified email in the list.
    * If the address is already verified we do not send any email.
    * @returns {Promise<void>} - Return a Promise.
+   *
+   * @throws {InvalidEmail} Will throw if email validation failed.
+   * @throws {UserNotFound} Will throw if user is not found. If option `ambiguousErrorMessages` is true, this will never throw.
    */
   public async sendVerificationEmail(address: string): Promise<void> {
     if (!address || !isString(address)) {
-      throw new Error(this.options.errors.invalidEmail);
+      throw new AccountsJsError(this.options.errors.invalidEmail, `InvalidEmail`);
     }
 
     const user = await this.db.findUserByEmail(address);
@@ -453,7 +456,7 @@ export default class AccountsPassword implements AuthenticationService {
       if (this.server.options.ambiguousErrorMessages) {
         return;
       }
-      throw new Error(this.options.errors.userNotFound);
+      throw new AccountsJsError(this.options.errors.userNotFound, `UserNotFound`);
     }
 
     // Do not send an email if the address is already verified
@@ -486,10 +489,13 @@ export default class AccountsPassword implements AuthenticationService {
    * This address must be in the user's emails list.
    * Defaults to the first email in the list.
    * @returns {Promise<void>} - Return a Promise.
+   *
+   * @throws {InvalidEmail} Will throw if email validation failed.
+   * @throws {UserNotFound} Will throw if user is not found. If option `ambiguousErrorMessages` is true, this will never throw.
    */
   public async sendResetPasswordEmail(address: string): Promise<void> {
     if (!address || !isString(address)) {
-      throw new Error(this.options.errors.invalidEmail);
+      throw new AccountsJsError(this.options.errors.invalidEmail, `InvalidEmail`);
     }
 
     const user = await this.db.findUserByEmail(address);
@@ -498,7 +504,7 @@ export default class AccountsPassword implements AuthenticationService {
       if (this.server.options.ambiguousErrorMessages) {
         return;
       }
-      throw new Error(this.options.errors.userNotFound);
+      throw new AccountsJsError(this.options.errors.userNotFound, `UserNotFound`);
     }
     const token = generateRandomToken();
     await this.db.addResetPasswordToken(user.id, address, token, 'reset');
@@ -522,15 +528,18 @@ export default class AccountsPassword implements AuthenticationService {
    * This address must be in the user's emails list.
    * Defaults to the first email in the list.
    * @returns {Promise<void>} - Return a Promise.
+   *
+   * @throws {InvalidEmail} Will throw if email validation failed.
+   * @throws {UserNotFound} Will throw if user is not found. If option `ambiguousErrorMessages` is true, this will never throw.
    */
   public async sendEnrollmentEmail(address: string): Promise<void> {
     if (!address || !isString(address)) {
-      throw new Error(this.options.errors.invalidEmail);
+      throw new AccountsJsError(this.options.errors.invalidEmail, `InvalidEmail`);
     }
 
     const user = await this.db.findUserByEmail(address);
     if (!user) {
-      throw new Error(this.options.errors.userNotFound);
+      throw new AccountsJsError(this.options.errors.userNotFound, `UserNotFound`);
     }
     const token = generateRandomToken();
     await this.db.addResetPasswordToken(user.id, address, token, 'enroll');

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -392,6 +392,9 @@ export default class AccountsPassword implements AuthenticationService {
    * @param {string} oldPassword - The user's current password.
    * @param {string} newPassword - A new password for the user.
    * @returns {Promise<void>} - Return a Promise.
+   *
+   * @throws {InvalidPassword} Password validation via option `validatePassword` failed.
+   * @throws {NoEmailSet} User has no email set.
    */
   public async changePassword(
     userId: string,
@@ -399,7 +402,7 @@ export default class AccountsPassword implements AuthenticationService {
     newPassword: string
   ): Promise<void> {
     if (!this.options.validatePassword(newPassword)) {
-      throw new Error(this.options.errors.invalidPassword);
+      throw new AccountsJsError(this.options.errors.invalidPassword, `InvalidPassword`);
     }
 
     const user = await this.passwordAuthenticator({ id: userId }, oldPassword);
@@ -416,7 +419,7 @@ export default class AccountsPassword implements AuthenticationService {
     if (this.options.notifyUserAfterPasswordChanged) {
       const address = user.emails && user.emails[0].address;
       if (!address) {
-        throw new Error(this.options.errors.noEmailSet);
+        throw new AccountsJsError(this.options.errors.noEmailSet, `NoEmailSet`);
       }
 
       const passwordChangedMail = this.server.prepareMail(
@@ -554,7 +557,7 @@ export default class AccountsPassword implements AuthenticationService {
    * @throws {InvalidEmail} Email validation via option `validateEmail` failed.
    * @throws {UsernameAlreadyExists} Username already exist in the database.
    * @throws {EmailAlreadyExists} Email already exist in the database.
-   * @throws {InvalidPassword} Email already exist in the database.
+   * @throws {InvalidPassword} Password validation via option `validatePassword` failed.
    */
   public async createUser(user: CreateUserServicePassword): Promise<string> {
     if (!user.username && !user.email) {

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -21,7 +21,16 @@ import {
   isEmail,
 } from './utils';
 import { ErrorMessages } from './types';
-import { errors } from './errors';
+import {
+  errors,
+  AddEmailErrors,
+  ChangePasswordErrors,
+  CreateUserErrors,
+  ResetPasswordErrors,
+  SendVerificationEmailErrors,
+  SendResetPasswordEmailErrors,
+  VerifyEmailErrors,
+} from './errors';
 
 // TODO move this to another package
 // TODO update docs and show how to handle these errors
@@ -33,48 +42,6 @@ class AccountsJsError extends Error {
     this.code = code;
     Object.setPrototypeOf(this, new.target.prototype);
   }
-}
-
-// TODO move it to a separate file
-enum CreateUserErrors {
-  InvalidUsername = 'InvalidUsername',
-  InvalidEmail = 'InvalidEmail',
-  InvalidPassword = 'InvalidPassword',
-  EmailAlreadyExists = 'EmailAlreadyExists',
-  UsernameAlreadyExists = 'UsernameAlreadyExists',
-}
-
-enum AddEmailErrors {
-  InvalidEmail = 'InvalidEmail',
-}
-
-enum VerifyEmailErrors {
-  InvalidToken = 'InvalidToken',
-  VerifyEmailLinkExpired = 'VerifyEmailLinkExpired',
-  VerifyEmailLinkUnknownAddress = 'VerifyEmailLinkUnknownAddress',
-}
-
-enum ResetPasswordErrors {
-  InvalidToken = 'InvalidToken',
-  InvalidNewPassword = 'InvalidNewPassword',
-  ResetPasswordLinkExpired = 'ResetPasswordLinkExpired',
-  ResetPasswordLinkUnknownAddress = 'ResetPasswordLinkUnknownAddress',
-  NoEmailSet = 'NoEmailSet',
-}
-
-enum ChangePasswordErrors {
-  InvalidPassword = 'InvalidPassword',
-  NoEmailSet = 'NoEmailSet',
-}
-
-enum SendVerificationEmailErrors {
-  InvalidEmail = 'InvalidEmail',
-  UserNotFound = 'UserNotFound',
-}
-
-enum SendResetPasswordEmailErrors {
-  InvalidEmail = 'InvalidEmail',
-  UserNotFound = 'UserNotFound',
 }
 
 export interface AccountsPasswordOptions {

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -218,8 +218,7 @@ export default class AccountsPassword implements AuthenticationService {
    * @param {boolean} [verified] - Whether the new email address should be marked as verified.
    * Defaults to false.
    * @returns {Promise<void>} - Return a Promise.
-   *
-   * @throws {InvalidEmail} Email validation via option `validateEmail` failed.
+   * @throws {@link AddEmailErrors}
    */
   public addEmail(userId: string, newEmail: string, verified = false): Promise<void> {
     if (!this.options.validateEmail(newEmail)) {
@@ -285,8 +284,8 @@ export default class AccountsPassword implements AuthenticationService {
    * It will trigger the `validatePassword` option and throw if password is invalid.
    * @param {string} token - The token retrieved from the reset password URL.
    * @param {string} newPassword - A new password for the user.
-   * @throws {@link ResetPasswordErrors}
    * @returns {Promise<LoginResult | null>} - If `returnTokensAfterResetPassword` option is true return the session tokens and user object, otherwise return null.
+   * @throws {@link ResetPasswordErrors}
    */
   public async resetPassword(
     token: string,

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -12,7 +12,12 @@ import {
   LoginUserPasswordService,
 } from '@accounts/types';
 import { TwoFactor, AccountsTwoFactorOptions, getUserTwoFactorService } from '@accounts/two-factor';
-import { AccountsServer, ServerHooks, generateRandomToken } from '@accounts/server';
+import {
+  AccountsServer,
+  ServerHooks,
+  generateRandomToken,
+  AccountsJsError,
+} from '@accounts/server';
 import {
   getUserResetTokens,
   getUserVerificationTokens,
@@ -31,18 +36,6 @@ import {
   SendResetPasswordEmailErrors,
   VerifyEmailErrors,
 } from './errors';
-
-// TODO move this to another package
-// TODO update docs and show how to handle these errors
-class AccountsJsError extends Error {
-  public code: string;
-
-  constructor(message: string, code: string) {
-    super(message);
-    this.code = code;
-    Object.setPrototypeOf(this, new.target.prototype);
-  }
-}
 
 export interface AccountsPasswordOptions {
   /**

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -237,6 +237,7 @@ export default class AccountsPassword implements AuthenticationService {
    *
    * @throws {InvalidToken} Will throw if token validation failed.
    * @throws {VerifyEmailLinkExpired} The token does not exist or is expired.
+   * @throws {VerifyEmailLinkUnknownAddress} The token is valid but no email address found for the entry.
    */
   public async verifyEmail(token: string): Promise<void> {
     if (!token || !isString(token)) {
@@ -263,8 +264,8 @@ export default class AccountsPassword implements AuthenticationService {
     const emailRecord = find(user.emails, (e: EmailRecord) => e.address === tokenRecord.address);
     if (!emailRecord) {
       throw new AccountsJsError(
-        this.options.errors.verifyEmailLinkExpired,
-        `VerifyEmailLinkExpired`
+        this.options.errors.verifyEmailLinkUnknownAddress,
+        `VerifyEmailLinkUnknownAddress`
       );
     }
     await this.db.verifyEmail(user.id, emailRecord.address);

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -34,6 +34,14 @@ class AccountsJsError extends Error {
   }
 }
 
+enum CreateUserErrors {
+  InvalidUsername = 'InvalidUsername',
+  InvalidEmail = 'InvalidEmail',
+  InvalidPassword = 'InvalidPassword',
+  EmailAlreadyExists = 'EmailAlreadyExists',
+  UsernameAlreadyExists = 'UsernameAlreadyExists',
+}
+
 export interface AccountsPasswordOptions {
   /**
    * Two factor options passed down to the @accounts/two-factor service.
@@ -577,24 +585,36 @@ export default class AccountsPassword implements AuthenticationService {
     }
 
     if (user.username && !this.options.validateUsername(user.username)) {
-      throw new AccountsJsError(this.options.errors.invalidUsername, 'InvalidUsername');
+      throw new AccountsJsError(
+        this.options.errors.invalidUsername,
+        CreateUserErrors.InvalidUsername
+      );
     }
 
     if (user.email && !this.options.validateEmail(user.email)) {
-      throw new AccountsJsError(this.options.errors.invalidEmail, 'InvalidEmail');
+      throw new AccountsJsError(this.options.errors.invalidEmail, CreateUserErrors.InvalidEmail);
     }
 
     if (user.username && (await this.db.findUserByUsername(user.username))) {
-      throw new AccountsJsError(this.options.errors.usernameAlreadyExists, 'UsernameAlreadyExists');
+      throw new AccountsJsError(
+        this.options.errors.usernameAlreadyExists,
+        CreateUserErrors.UsernameAlreadyExists
+      );
     }
 
     if (user.email && (await this.db.findUserByEmail(user.email))) {
-      throw new AccountsJsError(this.options.errors.emailAlreadyExists, 'EmailAlreadyExists');
+      throw new AccountsJsError(
+        this.options.errors.emailAlreadyExists,
+        CreateUserErrors.EmailAlreadyExists
+      );
     }
 
     if (user.password) {
       if (!this.options.validatePassword(user.password)) {
-        throw new AccountsJsError(this.options.errors.invalidPassword, 'InvalidPassword');
+        throw new AccountsJsError(
+          this.options.errors.invalidPassword,
+          CreateUserErrors.InvalidPassword
+        );
       }
       user.password = await this.options.hashPassword(user.password);
     }

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -54,6 +54,14 @@ enum VerifyEmailErrors {
   VerifyEmailLinkUnknownAddress = 'VerifyEmailLinkUnknownAddress',
 }
 
+enum ResetPasswordErrors {
+  InvalidToken = 'InvalidToken',
+  InvalidNewPassword = 'InvalidNewPassword',
+  ResetPasswordLinkExpired = 'ResetPasswordLinkExpired',
+  ResetPasswordLinkUnknownAddress = 'ResetPasswordLinkUnknownAddress',
+  NoEmailSet = 'NoEmailSet',
+}
+
 export interface AccountsPasswordOptions {
   /**
    * Two factor options passed down to the @accounts/two-factor service.
@@ -310,17 +318,20 @@ export default class AccountsPassword implements AuthenticationService {
     infos: ConnectionInformations
   ): Promise<LoginResult | null> {
     if (!token || !isString(token)) {
-      throw new AccountsJsError(this.options.errors.invalidToken, `InvalidToken`);
+      throw new AccountsJsError(this.options.errors.invalidToken, ResetPasswordErrors.InvalidToken);
     }
     if (!newPassword || !isString(newPassword)) {
-      throw new AccountsJsError(this.options.errors.invalidNewPassword, `InvalidNewPassword`);
+      throw new AccountsJsError(
+        this.options.errors.invalidNewPassword,
+        ResetPasswordErrors.InvalidNewPassword
+      );
     }
 
     const user = await this.db.findUserByResetPasswordToken(token);
     if (!user) {
       throw new AccountsJsError(
         this.options.errors.resetPasswordLinkExpired,
-        `ResetPasswordLinkExpired`
+        ResetPasswordErrors.ResetPasswordLinkExpired
       );
     }
 
@@ -338,7 +349,7 @@ export default class AccountsPassword implements AuthenticationService {
     ) {
       throw new AccountsJsError(
         this.options.errors.resetPasswordLinkExpired,
-        `ResetPasswordLinkExpired`
+        ResetPasswordErrors.ResetPasswordLinkExpired
       );
     }
 
@@ -351,7 +362,7 @@ export default class AccountsPassword implements AuthenticationService {
     ) {
       throw new AccountsJsError(
         this.options.errors.resetPasswordLinkUnknownAddress,
-        `ResetPasswordLinkUnknownAddress`
+        ResetPasswordErrors.ResetPasswordLinkUnknownAddress
       );
     }
 
@@ -374,7 +385,7 @@ export default class AccountsPassword implements AuthenticationService {
     if (this.options.notifyUserAfterPasswordChanged) {
       const address = user.emails && user.emails[0].address;
       if (!address) {
-        throw new AccountsJsError(this.options.errors.noEmailSet, `NoEmailSet`);
+        throw new AccountsJsError(this.options.errors.noEmailSet, ResetPasswordErrors.NoEmailSet);
       }
 
       const passwordChangedMail = this.server.prepareMail(

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -44,6 +44,16 @@ enum CreateUserErrors {
   UsernameAlreadyExists = 'UsernameAlreadyExists',
 }
 
+enum AddEmailErrors {
+  InvalidEmail = 'InvalidEmail',
+}
+
+enum VerifyEmailErrors {
+  InvalidToken = 'InvalidToken',
+  VerifyEmailLinkExpired = 'VerifyEmailLinkExpired',
+  VerifyEmailLinkUnknownAddress = 'VerifyEmailLinkUnknownAddress',
+}
+
 export interface AccountsPasswordOptions {
   /**
    * Two factor options passed down to the @accounts/two-factor service.
@@ -225,7 +235,7 @@ export default class AccountsPassword implements AuthenticationService {
    */
   public addEmail(userId: string, newEmail: string, verified = false): Promise<void> {
     if (!this.options.validateEmail(newEmail)) {
-      throw new AccountsJsError(this.options.errors.invalidEmail, `InvalidEmail`);
+      throw new AccountsJsError(this.options.errors.invalidEmail, AddEmailErrors.InvalidEmail);
     }
     return this.db.addEmail(userId, newEmail, verified);
   }
@@ -252,14 +262,14 @@ export default class AccountsPassword implements AuthenticationService {
    */
   public async verifyEmail(token: string): Promise<void> {
     if (!token || !isString(token)) {
-      throw new AccountsJsError(this.options.errors.invalidToken, `InvalidToken`);
+      throw new AccountsJsError(this.options.errors.invalidToken, VerifyEmailErrors.InvalidToken);
     }
 
     const user = await this.db.findUserByEmailVerificationToken(token);
     if (!user) {
       throw new AccountsJsError(
         this.options.errors.verifyEmailLinkExpired,
-        `VerifyEmailLinkExpired`
+        VerifyEmailErrors.VerifyEmailLinkExpired
       );
     }
 
@@ -268,7 +278,7 @@ export default class AccountsPassword implements AuthenticationService {
     if (!tokenRecord || this.isTokenExpired(tokenRecord, this.options.verifyEmailTokenExpiration)) {
       throw new AccountsJsError(
         this.options.errors.verifyEmailLinkExpired,
-        `VerifyEmailLinkExpired`
+        VerifyEmailErrors.VerifyEmailLinkExpired
       );
     }
 
@@ -276,7 +286,7 @@ export default class AccountsPassword implements AuthenticationService {
     if (!emailRecord) {
       throw new AccountsJsError(
         this.options.errors.verifyEmailLinkUnknownAddress,
-        `VerifyEmailLinkUnknownAddress`
+        VerifyEmailErrors.VerifyEmailLinkUnknownAddress
       );
     }
     await this.db.verifyEmail(user.id, emailRecord.address);

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -285,13 +285,8 @@ export default class AccountsPassword implements AuthenticationService {
    * It will trigger the `validatePassword` option and throw if password is invalid.
    * @param {string} token - The token retrieved from the reset password URL.
    * @param {string} newPassword - A new password for the user.
+   * @throws {@link ResetPasswordErrors}
    * @returns {Promise<LoginResult | null>} - If `returnTokensAfterResetPassword` option is true return the session tokens and user object, otherwise return null.
-   *
-   * @throws {InvalidToken} Will throw if token validation failed.
-   * @throws {InvalidNewPassword} Will throw if new password validation failed.
-   * @throws {ResetPasswordLinkExpired} The token does not exist or is expired.
-   * @throws {ResetPasswordLinkUnknownAddress} The token is valid but no email address found for the entry.
-   * @throws {NoEmailSet} User has no email set.
    */
   public async resetPassword(
     token: string,

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -23,6 +23,7 @@ import {
 import { ErrorMessages } from './types';
 import { errors } from './errors';
 
+// TODO move this to another package
 // TODO update docs and show how to handle these errors
 class AccountsJsError extends Error {
   public code: string;
@@ -34,6 +35,7 @@ class AccountsJsError extends Error {
   }
 }
 
+// TODO move it to a separate file
 enum CreateUserErrors {
   InvalidUsername = 'InvalidUsername',
   InvalidEmail = 'InvalidEmail',

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -36,6 +36,7 @@ import {
   ResetPasswordErrors,
   SendVerificationEmailErrors,
   SendResetPasswordEmailErrors,
+  SendEnrollmentEmailErrors,
   VerifyEmailErrors,
 } from './errors';
 
@@ -445,9 +446,7 @@ export default class AccountsPassword implements AuthenticationService {
    * Defaults to the first unverified email in the list.
    * If the address is already verified we do not send any email.
    * @returns {Promise<void>} - Return a Promise.
-   *
-   * @throws {InvalidEmail} Will throw if email validation failed.
-   * @throws {UserNotFound} Will throw if user is not found. If option `ambiguousErrorMessages` is true, this will never throw.
+   * @throws {@link SendVerificationEmailErrors}
    */
   public async sendVerificationEmail(address: string): Promise<void> {
     if (!address || !isString(address)) {
@@ -499,9 +498,7 @@ export default class AccountsPassword implements AuthenticationService {
    * This address must be in the user's emails list.
    * Defaults to the first email in the list.
    * @returns {Promise<void>} - Return a Promise.
-   *
-   * @throws {InvalidEmail} Will throw if email validation failed.
-   * @throws {UserNotFound} Will throw if user is not found. If option `ambiguousErrorMessages` is true, this will never throw.
+   * @throws {@link SendResetPasswordEmailErrors}
    */
   public async sendResetPasswordEmail(address: string): Promise<void> {
     if (!address || !isString(address)) {
@@ -544,18 +541,22 @@ export default class AccountsPassword implements AuthenticationService {
    * This address must be in the user's emails list.
    * Defaults to the first email in the list.
    * @returns {Promise<void>} - Return a Promise.
-   *
-   * @throws {InvalidEmail} Will throw if email validation failed.
-   * @throws {UserNotFound} Will throw if user is not found. If option `ambiguousErrorMessages` is true, this will never throw.
+   * @throws {@link SendEnrollmentEmailErrors}
    */
   public async sendEnrollmentEmail(address: string): Promise<void> {
     if (!address || !isString(address)) {
-      throw new AccountsJsError(this.options.errors.invalidEmail, `InvalidEmail`);
+      throw new AccountsJsError(
+        this.options.errors.invalidEmail,
+        SendEnrollmentEmailErrors.InvalidEmail
+      );
     }
 
     const user = await this.db.findUserByEmail(address);
     if (!user) {
-      throw new AccountsJsError(this.options.errors.userNotFound, `UserNotFound`);
+      throw new AccountsJsError(
+        this.options.errors.userNotFound,
+        SendEnrollmentEmailErrors.UserNotFound
+      );
     }
     const token = generateRandomToken();
     await this.db.addResetPasswordToken(user.id, address, token, 'enroll');
@@ -576,19 +577,13 @@ export default class AccountsPassword implements AuthenticationService {
    * @description Create a new user.
    * @param user - The user object.
    * @returns Return the id of user created.
-   *
-   * @throws {UsernameOrEmailRequired} Will throw if no username or email is.
-   * @throws {InvalidUsername} Username validation via option `validateUsername` failed.
-   * @throws {InvalidEmail} Email validation via option `validateEmail` failed.
-   * @throws {UsernameAlreadyExists} Username already exist in the database.
-   * @throws {EmailAlreadyExists} Email already exist in the database.
-   * @throws {InvalidPassword} Password validation via option `validatePassword` failed.
+   * @throws {@link CreateUserErrors}
    */
   public async createUser(user: CreateUserServicePassword): Promise<string> {
     if (!user.username && !user.email) {
       throw new AccountsJsError(
         this.options.errors.usernameOrEmailRequired,
-        `UsernameOrEmailRequired`
+        CreateUserErrors.UsernameOrEmailRequired
       );
     }
 

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -67,6 +67,11 @@ enum ChangePasswordErrors {
   NoEmailSet = 'NoEmailSet',
 }
 
+enum SendVerificationEmailErrors {
+  InvalidEmail = 'InvalidEmail',
+  UserNotFound = 'UserNotFound',
+}
+
 export interface AccountsPasswordOptions {
   /**
    * Two factor options passed down to the @accounts/two-factor service.
@@ -486,7 +491,10 @@ export default class AccountsPassword implements AuthenticationService {
    */
   public async sendVerificationEmail(address: string): Promise<void> {
     if (!address || !isString(address)) {
-      throw new AccountsJsError(this.options.errors.invalidEmail, `InvalidEmail`);
+      throw new AccountsJsError(
+        this.options.errors.invalidEmail,
+        SendVerificationEmailErrors.InvalidEmail
+      );
     }
 
     const user = await this.db.findUserByEmail(address);
@@ -495,7 +503,10 @@ export default class AccountsPassword implements AuthenticationService {
       if (this.server.options.ambiguousErrorMessages) {
         return;
       }
-      throw new AccountsJsError(this.options.errors.userNotFound, `UserNotFound`);
+      throw new AccountsJsError(
+        this.options.errors.userNotFound,
+        SendVerificationEmailErrors.UserNotFound
+      );
     }
 
     // Do not send an email if the address is already verified

--- a/packages/password/src/errors.ts
+++ b/packages/password/src/errors.ts
@@ -21,3 +21,44 @@ export const errors: ErrorMessages = {
   emailAlreadyExists: 'Email already exists',
   usernameOrEmailRequired: 'Username or Email is required',
 };
+
+export enum CreateUserErrors {
+  InvalidUsername = 'InvalidUsername',
+  InvalidEmail = 'InvalidEmail',
+  InvalidPassword = 'InvalidPassword',
+  EmailAlreadyExists = 'EmailAlreadyExists',
+  UsernameAlreadyExists = 'UsernameAlreadyExists',
+}
+
+export enum AddEmailErrors {
+  InvalidEmail = 'InvalidEmail',
+}
+
+export enum VerifyEmailErrors {
+  InvalidToken = 'InvalidToken',
+  VerifyEmailLinkExpired = 'VerifyEmailLinkExpired',
+  VerifyEmailLinkUnknownAddress = 'VerifyEmailLinkUnknownAddress',
+}
+
+export enum ResetPasswordErrors {
+  InvalidToken = 'InvalidToken',
+  InvalidNewPassword = 'InvalidNewPassword',
+  ResetPasswordLinkExpired = 'ResetPasswordLinkExpired',
+  ResetPasswordLinkUnknownAddress = 'ResetPasswordLinkUnknownAddress',
+  NoEmailSet = 'NoEmailSet',
+}
+
+export enum ChangePasswordErrors {
+  InvalidPassword = 'InvalidPassword',
+  NoEmailSet = 'NoEmailSet',
+}
+
+export enum SendVerificationEmailErrors {
+  InvalidEmail = 'InvalidEmail',
+  UserNotFound = 'UserNotFound',
+}
+
+export enum SendResetPasswordEmailErrors {
+  InvalidEmail = 'InvalidEmail',
+  UserNotFound = 'UserNotFound',
+}

--- a/packages/password/src/errors.ts
+++ b/packages/password/src/errors.ts
@@ -23,10 +23,29 @@ export const errors: ErrorMessages = {
 };
 
 export enum CreateUserErrors {
+  /**
+   * Will throw if no username or email is provided.
+   */
+  UsernameOrEmailRequired = 'UsernameOrEmailRequired',
+  /**
+   * Username validation via option `validateUsername` failed.
+   */
   InvalidUsername = 'InvalidUsername',
+  /**
+   * Email validation via option `validateEmail` failed.
+   */
   InvalidEmail = 'InvalidEmail',
+  /**
+   * Password validation via option `validatePassword` failed.
+   */
   InvalidPassword = 'InvalidPassword',
+  /**
+   * Email already exist in the database.
+   */
   EmailAlreadyExists = 'EmailAlreadyExists',
+  /**
+   * Username already exist in the database.
+   */
   UsernameAlreadyExists = 'UsernameAlreadyExists',
 }
 
@@ -109,11 +128,37 @@ export enum ChangePasswordErrors {
 }
 
 export enum SendVerificationEmailErrors {
+  /**
+   * Will throw if email validation failed.
+   */
   InvalidEmail = 'InvalidEmail',
+  /**
+   * Will throw if user is not found.
+   * If option `ambiguousErrorMessages` is true, this will never throw.
+   */
   UserNotFound = 'UserNotFound',
 }
 
 export enum SendResetPasswordEmailErrors {
+  /**
+   * Will throw if email validation failed.
+   */
   InvalidEmail = 'InvalidEmail',
+  /**
+   * Will throw if user is not found.
+   * If option `ambiguousErrorMessages` is true, this will never throw.
+   */
+  UserNotFound = 'UserNotFound',
+}
+
+export enum SendEnrollmentEmailErrors {
+  /**
+   * Will throw if email validation failed.
+   */
+  InvalidEmail = 'InvalidEmail',
+  /**
+   * Will throw if user is not found.
+   * If option `ambiguousErrorMessages` is true, this will never throw.
+   */
   UserNotFound = 'UserNotFound',
 }

--- a/packages/password/src/errors.ts
+++ b/packages/password/src/errors.ts
@@ -38,8 +38,17 @@ export enum AddEmailErrors {
 }
 
 export enum VerifyEmailErrors {
+  /**
+   * Will throw if token validation failed.
+   */
   InvalidToken = 'InvalidToken',
+  /**
+   * The token does not exist or is expired.
+   */
   VerifyEmailLinkExpired = 'VerifyEmailLinkExpired',
+  /**
+   * The token is valid but no email address found for the entry.
+   */
   VerifyEmailLinkUnknownAddress = 'VerifyEmailLinkUnknownAddress',
 }
 

--- a/packages/password/src/errors.ts
+++ b/packages/password/src/errors.ts
@@ -31,6 +31,9 @@ export enum CreateUserErrors {
 }
 
 export enum AddEmailErrors {
+  /**
+   * Email validation via option `validateEmail` failed.
+   */
   InvalidEmail = 'InvalidEmail',
 }
 

--- a/packages/password/src/errors.ts
+++ b/packages/password/src/errors.ts
@@ -48,9 +48,31 @@ export enum ResetPasswordErrors {
   NoEmailSet = 'NoEmailSet',
 }
 
+export enum PasswordAuthenticatorErrors {
+  InvalidCredentials = 'InvalidCredentials',
+  UserNotFound = 'UserNotFound',
+  IncorrectPassword = 'IncorrectPassword',
+  NoPasswordSet = 'NoPasswordSet',
+}
+
+export enum AuthenticateErrors {
+  UnrecognizedOptionsForLogin = 'UnrecognizedOptionsForLogin',
+  MatchFailed = 'MatchFailed',
+  // thrown by PasswordAuthenticatorErrors
+  InvalidCredentials = 'InvalidCredentials',
+  UserNotFound = 'UserNotFound',
+  IncorrectPassword = 'IncorrectPassword',
+  NoPasswordSet = 'NoPasswordSet',
+}
+
 export enum ChangePasswordErrors {
   InvalidPassword = 'InvalidPassword',
   NoEmailSet = 'NoEmailSet',
+  // thrown by PasswordAuthenticatorErrors
+  InvalidCredentials = 'InvalidCredentials',
+  UserNotFound = 'UserNotFound',
+  IncorrectPassword = 'IncorrectPassword',
+  NoPasswordSet = 'NoPasswordSet',
 }
 
 export enum SendVerificationEmailErrors {

--- a/packages/password/src/errors.ts
+++ b/packages/password/src/errors.ts
@@ -93,7 +93,13 @@ export enum AuthenticateErrors {
 }
 
 export enum ChangePasswordErrors {
+  /**
+   * Password validation via option `validatePassword` failed.
+   */
   InvalidPassword = 'InvalidPassword',
+  /**
+   * User has no email set.
+   */
   NoEmailSet = 'NoEmailSet',
   // thrown by PasswordAuthenticatorErrors
   InvalidCredentials = 'InvalidCredentials',

--- a/packages/password/src/errors.ts
+++ b/packages/password/src/errors.ts
@@ -41,10 +41,25 @@ export enum VerifyEmailErrors {
 }
 
 export enum ResetPasswordErrors {
+  /**
+   * Will throw if token validation failed.
+   */
   InvalidToken = 'InvalidToken',
+  /**
+   * Password validation via option `validatePassword` failed.
+   */
   InvalidNewPassword = 'InvalidNewPassword',
+  /**
+   * The token does not exist or is expired.
+   */
   ResetPasswordLinkExpired = 'ResetPasswordLinkExpired',
+  /**
+   * The token is valid but no email address found for the entry.
+   */
   ResetPasswordLinkUnknownAddress = 'ResetPasswordLinkUnknownAddress',
+  /**
+   * User has no email set.
+   */
   NoEmailSet = 'NoEmailSet',
 }
 

--- a/packages/password/src/index.ts
+++ b/packages/password/src/index.ts
@@ -1,5 +1,14 @@
 import AccountsPassword from './accounts-password';
 export * from './types';
+export {
+  AddEmailErrors,
+  ChangePasswordErrors,
+  CreateUserErrors,
+  ResetPasswordErrors,
+  SendVerificationEmailErrors,
+  SendResetPasswordEmailErrors,
+  VerifyEmailErrors,
+} from './errors';
 
 export default AccountsPassword;
 export { AccountsPassword };

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -3,6 +3,7 @@ export { AccountsServerOptions } from './types/accounts-server-options';
 export { generateRandomToken } from './utils/tokens';
 export { getFirstUserEmail } from './utils/get-first-user-email';
 export { ServerHooks } from './utils/server-hooks';
+export { AccountsJsError } from './utils/accounts-error';
 
 export default AccountsServer;
 export { AccountsServer };

--- a/packages/server/src/utils/accounts-error.ts
+++ b/packages/server/src/utils/accounts-error.ts
@@ -1,0 +1,9 @@
+export class AccountsJsError extends Error {
+  public code: string;
+
+  constructor(message: string, code: string) {
+    super(message);
+    this.code = code;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/website/docs/handling-errors.md
+++ b/website/docs/handling-errors.md
@@ -1,0 +1,35 @@
+---
+id: handling-errors
+title: Handling errors
+sidebar_label: 'Handling errors'
+---
+
+In order to have descriptive error messages and codes on the server we use a generic error named `AccountsJsError`. This error provide a `message` property containing a descriptive error message (eg: "Email already exists"). It also provides a `code` property that is reflecting a constant value to the error (eg: `EmailAlreadyExists`).
+
+Every public server function is exporting a custom enum describing all the possible errors.
+
+You can catch errors and do some custom logic based on the error like this:
+
+```ts
+import { AccountsJsError } from '@accounts/server';
+import { CreateUserErrors } from '@accounts/password';
+
+try {
+  await accountsPassword.createUser({
+    // ...
+  });
+} catch (error) {
+  if (error instanceof AccountsJsError) {
+    // You can access the error message via `error.message`
+    // Eg: "Email already exists"
+    // You can access the code via `error.code`
+    // Eg:
+    if (error.code === CreateUserErrors.EmailAlreadyExists) {
+      // do some custom logic
+    }
+  } else {
+    // Else means it's an internal server error so you probably want to obfuscate it and return
+    // a generic "Internal server error" to the user.
+  }
+}
+```

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -26,7 +26,7 @@ dirs.forEach(dir => {
 module.exports = {
   docs: {
     Introduction: ['introduction', 'contributing'],
-    'Getting started': ['getting-started', 'email', 'client'],
+    'Getting started': ['getting-started', 'handling-errors', 'email', 'client'],
     Transports: [
       'transports/graphql',
       {


### PR DESCRIPTION
The idea is to throw some custom errors with a code attached to them. That way the user can whitelist all the possible errors and consider the other ones as internal server errors.

There are a few requirements:
- each public function should expose an enum containing all the possible errors
- all the errors should be documented

You can use them the following way:

```ts
import { AccountsJsError } from '@accounts/server';
import { CreateUserErrors } from '@accounts/password';

const run = async () => {
  try {
    await accountsPassword.createUser({
      // ...
    });
  } catch (error) {
    if (error instanceof AccountsJsError) {
      // you can access the error message via `error.message`, eg: "Email already exists"
      // you can access the code via `error.code`
      // eg:
      if (error.code === CreateUserErrors.EmailAlreadyExists) {
        // do some custom logic
      }
    }
    // else means it's an internal server error
  }
};
```

The generated API documentation will look like this:

![Screenshot 2020-02-21 at 10 20 19](https://user-images.githubusercontent.com/5749437/75020927-e78e2680-5493-11ea-922d-9f0b439e081e.png)

If you click on the link you will arrive on the enum page describing all the errors.

![Screenshot 2020-02-21 at 10 20 37](https://user-images.githubusercontent.com/5749437/75020941-ea891700-5493-11ea-9069-d4dc9dbf1e11.png)


After this pr is merged, I will do the server part.