### PR TITLE
feat(rest-express): return the new error code

### DIFF
--- a/packages/rest-express/src/utils/send-error.ts
+++ b/packages/rest-express/src/utils/send-error.ts
@@ -1,6 +1,5 @@
 export const sendError = (res: any, err: any) =>
   res.status(400).json({
     message: err.message,
-    loginInfo: err.loginInfo,
-    errorCode: err.errorCode,
+    code: err.code,
   });


### PR DESCRIPTION
The rest express package will now return the code with the error message.

Example response:

```json
{"message":"Invalid credentials","code":"InvalidCredentials"}
```