### PR TITLE
feat(password): remove reset password tokens on change password

### DIFF
--- a/packages/database-manager/__tests__/database-manager.ts
+++ b/packages/database-manager/__tests__/database-manager.ts
@@ -84,6 +84,10 @@ export default class Database {
     return this.name;
   }
 
+  public removeAllPasswordResetTokens() {
+    return this.name;
+  }
+
   public findSessionByToken() {
     return this.name;
   }

--- a/packages/database-manager/__tests__/database-manager.ts
+++ b/packages/database-manager/__tests__/database-manager.ts
@@ -249,4 +249,8 @@ describe('DatabaseManager', () => {
   it('setUserDeactivated should be called on sessionStorage', () => {
     expect(databaseManager.setUserDeactivated('userId', true)).toBe('userStorage');
   });
+
+  it('removeAllPasswordResetTokens should be called on sessionStorage', () => {
+    expect(databaseManager.removeAllPasswordResetTokens('userId')).toBe('userStorage');
+  });
 });

--- a/packages/database-manager/__tests__/database-manager.ts
+++ b/packages/database-manager/__tests__/database-manager.ts
@@ -250,7 +250,7 @@ describe('DatabaseManager', () => {
     expect(databaseManager.setUserDeactivated('userId', true)).toBe('userStorage');
   });
 
-  it('removeAllPasswordResetTokens should be called on sessionStorage', () => {
+  it('removeAllPasswordResetTokens should be called on userStorage', () => {
     expect(databaseManager.removeAllPasswordResetTokens('userId')).toBe('userStorage');
   });
 });

--- a/packages/database-manager/__tests__/database-manager.ts
+++ b/packages/database-manager/__tests__/database-manager.ts
@@ -84,7 +84,7 @@ export default class Database {
     return this.name;
   }
 
-  public removeAllPasswordResetTokens() {
+  public removeAllResetPasswordTokens() {
     return this.name;
   }
 
@@ -250,7 +250,7 @@ describe('DatabaseManager', () => {
     expect(databaseManager.setUserDeactivated('userId', true)).toBe('userStorage');
   });
 
-  it('removeAllPasswordResetTokens should be called on userStorage', () => {
-    expect(databaseManager.removeAllPasswordResetTokens('userId')).toBe('userStorage');
+  it('removeAllResetPasswordTokens should be called on userStorage', () => {
+    expect(databaseManager.removeAllResetPasswordTokens('userId')).toBe('userStorage');
   });
 });

--- a/packages/database-manager/src/database-manager.ts
+++ b/packages/database-manager/src/database-manager.ts
@@ -125,6 +125,11 @@ export class DatabaseManager implements DatabaseInterface {
     return this.sessionStorage.invalidateAllSessions.bind(this.sessionStorage);
   }
 
+  // Return the removeAllPasswordResetTokens function from the sessionStorage
+  public get removeAllPasswordResetTokens(): DatabaseInterface['removeAllPasswordResetTokens'] {
+    return this.sessionStorage.removeAllPasswordResetTokens.bind(this.sessionStorage);
+  }
+
   // Return the findSessionByToken function from the sessionStorage
   public get findSessionByToken(): DatabaseInterface['findSessionByToken'] {
     return this.sessionStorage.findSessionByToken.bind(this.sessionStorage);

--- a/packages/database-manager/src/database-manager.ts
+++ b/packages/database-manager/src/database-manager.ts
@@ -125,9 +125,9 @@ export class DatabaseManager implements DatabaseInterface {
     return this.sessionStorage.invalidateAllSessions.bind(this.sessionStorage);
   }
 
-  // Return the removeAllResertPasswordTokens function from the sessionStorage
-  public get removeAllResertPasswordTokens(): DatabaseInterface['removeAllResertPasswordTokens'] {
-    return this.userStorage.removeAllResertPasswordTokens.bind(this.userStorage);
+  // Return the removeAllResetPasswordTokens function from the sessionStorage
+  public get removeAllResetPasswordTokens(): DatabaseInterface['removeAllResetPasswordTokens'] {
+    return this.userStorage.removeAllResetPasswordTokens.bind(this.userStorage);
   }
 
   // Return the findSessionByToken function from the sessionStorage

--- a/packages/database-manager/src/database-manager.ts
+++ b/packages/database-manager/src/database-manager.ts
@@ -127,7 +127,7 @@ export class DatabaseManager implements DatabaseInterface {
 
   // Return the removeAllPasswordResetTokens function from the sessionStorage
   public get removeAllPasswordResetTokens(): DatabaseInterface['removeAllPasswordResetTokens'] {
-    return this.userStorage.removeAllPasswordResetTokens.bind(this.sessionStorage);
+    return this.userStorage.removeAllPasswordResetTokens.bind(this.userStorage);
   }
 
   // Return the findSessionByToken function from the sessionStorage

--- a/packages/database-manager/src/database-manager.ts
+++ b/packages/database-manager/src/database-manager.ts
@@ -127,7 +127,7 @@ export class DatabaseManager implements DatabaseInterface {
 
   // Return the removeAllPasswordResetTokens function from the sessionStorage
   public get removeAllPasswordResetTokens(): DatabaseInterface['removeAllPasswordResetTokens'] {
-    return this.sessionStorage.removeAllPasswordResetTokens.bind(this.sessionStorage);
+    return this.userStorage.removeAllPasswordResetTokens.bind(this.sessionStorage);
   }
 
   // Return the findSessionByToken function from the sessionStorage

--- a/packages/database-manager/src/database-manager.ts
+++ b/packages/database-manager/src/database-manager.ts
@@ -125,9 +125,9 @@ export class DatabaseManager implements DatabaseInterface {
     return this.sessionStorage.invalidateAllSessions.bind(this.sessionStorage);
   }
 
-  // Return the removeAllPasswordResetTokens function from the sessionStorage
-  public get removeAllPasswordResetTokens(): DatabaseInterface['removeAllPasswordResetTokens'] {
-    return this.userStorage.removeAllPasswordResetTokens.bind(this.userStorage);
+  // Return the removeAllResertPasswordTokens function from the sessionStorage
+  public get removeAllResertPasswordTokens(): DatabaseInterface['removeAllResertPasswordTokens'] {
+    return this.userStorage.removeAllResertPasswordTokens.bind(this.userStorage);
   }
 
   // Return the findSessionByToken function from the sessionStorage

--- a/packages/database-mongo/__tests__/index.ts
+++ b/packages/database-mongo/__tests__/index.ts
@@ -731,7 +731,8 @@ describe('Mongo', () => {
       const mongoOptions = new Mongo(databaseTests.db, {
         convertUserIdToMongoObjectId: false,
       });
-      await mongoOptions.setService('toto', 'twitter', { id: '1' });
+      const userId = await mongoOptions.createUser(user);
+      await mongoOptions.removeAllPasswordResetTokens(userId);
     });
 
     it('should remove the password reset tokens', async () => {

--- a/packages/database-mongo/__tests__/index.ts
+++ b/packages/database-mongo/__tests__/index.ts
@@ -3,7 +3,6 @@ import { ObjectID, ObjectId } from 'mongodb';
 
 import { Mongo } from '../src';
 import { DatabaseTests } from './database-tests';
-import { isMainThread } from 'worker_threads';
 
 const databaseTests = new DatabaseTests();
 
@@ -737,15 +736,11 @@ describe('Mongo', () => {
 
     it('should remove the password reset tokens', async () => {
       const testToken = 'testVerificationToken';
+      const testReason = 'testReason';
       const userId = await databaseTests.database.createUser(user);
-      await databaseTests.database.addResetPasswordToken(
-        userId,
-        'test@test.test',
-        testToken,
-        'testReason'
-      );
-      const user = await databaseTests.database.findUserByResetPasswordToken(testToken);
-      expect(user).toBeTruthy();
+      await databaseTests.database.addResetPasswordToken(userId, user.email, testToken, testReason);
+      const userWithTokens = await databaseTests.database.findUserByResetPasswordToken(testToken);
+      expect(userWithTokens).toBeTruthy();
       await databaseTests.database.removeAllPasswordResetTokens(userId);
       const userWithDeletedTokens = await databaseTests.database.findUserByResetPasswordToken(
         testToken

--- a/packages/database-mongo/__tests__/index.ts
+++ b/packages/database-mongo/__tests__/index.ts
@@ -725,14 +725,14 @@ describe('Mongo', () => {
     });
   });
 
-  describe('removeAllPasswordResetTokens', () => {
+  describe('removeAllResetPasswordTokens', () => {
     // eslint-disable-next-line jest/expect-expect
     it('should not convert id', async () => {
       const mongoOptions = new Mongo(databaseTests.db, {
         convertUserIdToMongoObjectId: false,
       });
       const userId = await mongoOptions.createUser(user);
-      await mongoOptions.removeAllPasswordResetTokens(userId);
+      await mongoOptions.removeAllResetPasswordTokens(userId);
     });
 
     it('should remove the password reset tokens', async () => {
@@ -742,7 +742,7 @@ describe('Mongo', () => {
       await databaseTests.database.addResetPasswordToken(userId, user.email, testToken, testReason);
       const userWithTokens = await databaseTests.database.findUserByResetPasswordToken(testToken);
       expect(userWithTokens).toBeTruthy();
-      await databaseTests.database.removeAllPasswordResetTokens(userId);
+      await databaseTests.database.removeAllResetPasswordTokens(userId);
       const userWithDeletedTokens = await databaseTests.database.findUserByResetPasswordToken(
         testToken
       );

--- a/packages/database-mongo/__tests__/index.ts
+++ b/packages/database-mongo/__tests__/index.ts
@@ -747,12 +747,6 @@ describe('Mongo', () => {
       );
       expect(userWithDeletedTokens).not.toBeTruthy();
     });
-
-    it('should throw if user is not found', async () => {
-      await expect(
-        databaseTests.database.removeAllPasswordResetTokens('unknownUserId')
-      ).rejects.toThrowError('User not found');
-    });
   });
 
   describe('addEmailVerificationToken', () => {

--- a/packages/database-mongo/__tests__/index.ts
+++ b/packages/database-mongo/__tests__/index.ts
@@ -735,103 +735,109 @@ describe('Mongo', () => {
       await mongoOptions.setService('toto', 'twitter', { id: '1' });
     });
 
-    // it('should remove the password reset tokens', async () => {
-    //   const userId = await databaseTests.database.createUser(user);
-    //   let ret = await databaseTests.database.addResetPasswordToken(userId,'test@test.test', 'testVerificationToken', 'testReason');
-
-    //   });
-    // expect(ret).not.toBeTruthy();
-    // await databaseTests.database.setService(userId, 'google', { id: '1' });
-    // ret = await databaseTests.database.findUserByServiceId('google', '1');
-    // expect(ret).toBeTruthy();
-    // expect((ret as any)._id).toBeTruthy();
-    // expect(ret!.id).toBeTruthy();
-  });
-
-  // it('should throw if user is not found', async () => {
-  //   await expect(
-  //     databaseTests.database.addEmail('589871d1c9393d445745a57c', 'unknowemail', false)
-  //   ).rejects.toThrowError('User not found');
-  // });
-});
-
-describe('addEmailVerificationToken', () => {
-  // eslint-disable-next-line jest/expect-expect
-  it('should not convert id', async () => {
-    const mongoOptions = new Mongo(databaseTests.db, {
-      convertUserIdToMongoObjectId: false,
-      idProvider: () => new ObjectId().toString(),
+    it('should remove the password reset tokens', async () => {
+      const testToken = 'testVerificationToken';
+      const userId = await databaseTests.database.createUser(user);
+      await databaseTests.database.addResetPasswordToken(
+        userId,
+        'test@test.test',
+        testToken,
+        'testReason'
+      );
+      const user = await databaseTests.database.findUserByResetPasswordToken(testToken);
+      expect(user).toBeTruthy();
+      await databaseTests.database.removeAllPasswordResetTokens(userId);
+      const userWithDeletedTokens = await databaseTests.database.findUserByResetPasswordToken(
+        testToken
+      );
+      expect(userWithDeletedTokens).not.toBeTruthy();
     });
-    const userId = await mongoOptions.createUser(user);
-    await mongoOptions.addEmailVerificationToken(userId, 'john@doe.com', 'token');
-  });
 
-  it('should add a token', async () => {
-    const userId = await databaseTests.database.createUser(user);
-    await databaseTests.database.addEmailVerificationToken(userId, 'john@doe.com', 'token');
-    const retUser = await databaseTests.database.findUserById(userId);
-    const services: any = retUser!.services;
-    expect(services.email.verificationTokens.length).toEqual(1);
-    expect(services.email.verificationTokens[0].address).toEqual('john@doe.com');
-    expect(services.email.verificationTokens[0].token).toEqual('token');
-    expect(services.email.verificationTokens[0].when).toBeTruthy();
-  });
-});
-
-describe('addResetPasswordToken', () => {
-  // eslint-disable-next-line jest/expect-expect
-  it('should not convert id', async () => {
-    const mongoOptions = new Mongo(databaseTests.db, {
-      convertUserIdToMongoObjectId: false,
-      idProvider: () => new ObjectId().toString(),
+    it('should throw if user is not found', async () => {
+      await expect(
+        databaseTests.database.removeAllPasswordResetTokens('unknownUserId')
+      ).rejects.toThrowError('User not found');
     });
-    const userId = await mongoOptions.createUser(user);
-    await mongoOptions.addResetPasswordToken(userId, 'john@doe.com', 'token', 'reset');
   });
 
-  it('should add a token', async () => {
-    const userId = await databaseTests.database.createUser(user);
-    await databaseTests.database.addResetPasswordToken(userId, 'john@doe.com', 'token', 'reset');
-    const retUser = await databaseTests.database.findUserById(userId);
-    const services: any = retUser!.services;
-    expect(services.password.reset.length).toEqual(1);
-    expect(services.password.reset[0].address).toEqual('john@doe.com');
-    expect(services.password.reset[0].token).toEqual('token');
-    expect(services.password.reset[0].when).toBeTruthy();
-    expect(services.password.reset[0].reason).toEqual('reset');
-  });
-});
-
-describe('setResetPassword', () => {
-  it('should change password', async () => {
-    const newPassword = 'newpass';
-    const userId = await databaseTests.database.createUser(user);
-    await delay(10);
-    await databaseTests.database.setResetPassword(userId, 'toto', newPassword);
-    const retUser = await databaseTests.database.findUserById(userId);
-    const services: any = retUser!.services;
-    expect(services.password.bcrypt).toBeTruthy();
-    expect(services.password.bcrypt).toEqual(newPassword);
-    expect((retUser as any).createdAt).not.toEqual((retUser as any).updatedAt);
-  });
-});
-
-describe('setUserDeactivated', () => {
-  // eslint-disable-next-line jest/expect-expect
-  it('should not convert id', async () => {
-    const mongoOptions = new Mongo(databaseTests.db, {
-      convertUserIdToMongoObjectId: false,
-      idProvider: () => new ObjectId().toString(),
+  describe('addEmailVerificationToken', () => {
+    // eslint-disable-next-line jest/expect-expect
+    it('should not convert id', async () => {
+      const mongoOptions = new Mongo(databaseTests.db, {
+        convertUserIdToMongoObjectId: false,
+        idProvider: () => new ObjectId().toString(),
+      });
+      const userId = await mongoOptions.createUser(user);
+      await mongoOptions.addEmailVerificationToken(userId, 'john@doe.com', 'token');
     });
-    const userId = await mongoOptions.createUser(user);
-    await mongoOptions.setUserDeactivated(userId, true);
+
+    it('should add a token', async () => {
+      const userId = await databaseTests.database.createUser(user);
+      await databaseTests.database.addEmailVerificationToken(userId, 'john@doe.com', 'token');
+      const retUser = await databaseTests.database.findUserById(userId);
+      const services: any = retUser!.services;
+      expect(services.email.verificationTokens.length).toEqual(1);
+      expect(services.email.verificationTokens[0].address).toEqual('john@doe.com');
+      expect(services.email.verificationTokens[0].token).toEqual('token');
+      expect(services.email.verificationTokens[0].when).toBeTruthy();
+    });
   });
 
-  it('should deactivate user', async () => {
-    const userId = await databaseTests.database.createUser(user);
-    await databaseTests.database.setUserDeactivated(userId, true);
-    const retUser = await databaseTests.database.findUserById(userId);
-    expect(retUser!.deactivated).toBeTruthy();
-    expect((retUser as any).createdAt).not.toEqual((retUser as any).updatedAt);
+  describe('addResetPasswordToken', () => {
+    // eslint-disable-next-line jest/expect-expect
+    it('should not convert id', async () => {
+      const mongoOptions = new Mongo(databaseTests.db, {
+        convertUserIdToMongoObjectId: false,
+        idProvider: () => new ObjectId().toString(),
+      });
+      const userId = await mongoOptions.createUser(user);
+      await mongoOptions.addResetPasswordToken(userId, 'john@doe.com', 'token', 'reset');
+    });
+
+    it('should add a token', async () => {
+      const userId = await databaseTests.database.createUser(user);
+      await databaseTests.database.addResetPasswordToken(userId, 'john@doe.com', 'token', 'reset');
+      const retUser = await databaseTests.database.findUserById(userId);
+      const services: any = retUser!.services;
+      expect(services.password.reset.length).toEqual(1);
+      expect(services.password.reset[0].address).toEqual('john@doe.com');
+      expect(services.password.reset[0].token).toEqual('token');
+      expect(services.password.reset[0].when).toBeTruthy();
+      expect(services.password.reset[0].reason).toEqual('reset');
+    });
+  });
+
+  describe('setResetPassword', () => {
+    it('should change password', async () => {
+      const newPassword = 'newpass';
+      const userId = await databaseTests.database.createUser(user);
+      await delay(10);
+      await databaseTests.database.setResetPassword(userId, 'toto', newPassword);
+      const retUser = await databaseTests.database.findUserById(userId);
+      const services: any = retUser!.services;
+      expect(services.password.bcrypt).toBeTruthy();
+      expect(services.password.bcrypt).toEqual(newPassword);
+      expect((retUser as any).createdAt).not.toEqual((retUser as any).updatedAt);
+    });
+  });
+
+  describe('setUserDeactivated', () => {
+    // eslint-disable-next-line jest/expect-expect
+    it('should not convert id', async () => {
+      const mongoOptions = new Mongo(databaseTests.db, {
+        convertUserIdToMongoObjectId: false,
+        idProvider: () => new ObjectId().toString(),
+      });
+      const userId = await mongoOptions.createUser(user);
+      await mongoOptions.setUserDeactivated(userId, true);
+    });
+
+    it('should deactivate user', async () => {
+      const userId = await databaseTests.database.createUser(user);
+      await databaseTests.database.setUserDeactivated(userId, true);
+      const retUser = await databaseTests.database.findUserById(userId);
+      expect(retUser!.deactivated).toBeTruthy();
+      expect((retUser as any).createdAt).not.toEqual((retUser as any).updatedAt);
+    });
   });
 });

--- a/packages/database-mongo/__tests__/index.ts
+++ b/packages/database-mongo/__tests__/index.ts
@@ -3,6 +3,7 @@ import { ObjectID, ObjectId } from 'mongodb';
 
 import { Mongo } from '../src';
 import { DatabaseTests } from './database-tests';
+import { isMainThread } from 'worker_threads';
 
 const databaseTests = new DatabaseTests();
 
@@ -725,84 +726,112 @@ describe('Mongo', () => {
     });
   });
 
-  describe('addEmailVerificationToken', () => {
+  describe('removeAllPasswordResetTokens', () => {
     // eslint-disable-next-line jest/expect-expect
     it('should not convert id', async () => {
       const mongoOptions = new Mongo(databaseTests.db, {
         convertUserIdToMongoObjectId: false,
-        idProvider: () => new ObjectId().toString(),
       });
-      const userId = await mongoOptions.createUser(user);
-      await mongoOptions.addEmailVerificationToken(userId, 'john@doe.com', 'token');
+      await mongoOptions.setService('toto', 'twitter', { id: '1' });
     });
 
-    it('should add a token', async () => {
-      const userId = await databaseTests.database.createUser(user);
-      await databaseTests.database.addEmailVerificationToken(userId, 'john@doe.com', 'token');
-      const retUser = await databaseTests.database.findUserById(userId);
-      const services: any = retUser!.services;
-      expect(services.email.verificationTokens.length).toEqual(1);
-      expect(services.email.verificationTokens[0].address).toEqual('john@doe.com');
-      expect(services.email.verificationTokens[0].token).toEqual('token');
-      expect(services.email.verificationTokens[0].when).toBeTruthy();
-    });
+    // it('should remove the password reset tokens', async () => {
+    //   const userId = await databaseTests.database.createUser(user);
+    //   let ret = await databaseTests.database.addResetPasswordToken(userId,'test@test.test', 'testVerificationToken', 'testReason');
+
+    //   });
+    // expect(ret).not.toBeTruthy();
+    // await databaseTests.database.setService(userId, 'google', { id: '1' });
+    // ret = await databaseTests.database.findUserByServiceId('google', '1');
+    // expect(ret).toBeTruthy();
+    // expect((ret as any)._id).toBeTruthy();
+    // expect(ret!.id).toBeTruthy();
   });
 
-  describe('addResetPasswordToken', () => {
-    // eslint-disable-next-line jest/expect-expect
-    it('should not convert id', async () => {
-      const mongoOptions = new Mongo(databaseTests.db, {
-        convertUserIdToMongoObjectId: false,
-        idProvider: () => new ObjectId().toString(),
-      });
-      const userId = await mongoOptions.createUser(user);
-      await mongoOptions.addResetPasswordToken(userId, 'john@doe.com', 'token', 'reset');
-    });
+  // it('should throw if user is not found', async () => {
+  //   await expect(
+  //     databaseTests.database.addEmail('589871d1c9393d445745a57c', 'unknowemail', false)
+  //   ).rejects.toThrowError('User not found');
+  // });
+});
 
-    it('should add a token', async () => {
-      const userId = await databaseTests.database.createUser(user);
-      await databaseTests.database.addResetPasswordToken(userId, 'john@doe.com', 'token', 'reset');
-      const retUser = await databaseTests.database.findUserById(userId);
-      const services: any = retUser!.services;
-      expect(services.password.reset.length).toEqual(1);
-      expect(services.password.reset[0].address).toEqual('john@doe.com');
-      expect(services.password.reset[0].token).toEqual('token');
-      expect(services.password.reset[0].when).toBeTruthy();
-      expect(services.password.reset[0].reason).toEqual('reset');
+describe('addEmailVerificationToken', () => {
+  // eslint-disable-next-line jest/expect-expect
+  it('should not convert id', async () => {
+    const mongoOptions = new Mongo(databaseTests.db, {
+      convertUserIdToMongoObjectId: false,
+      idProvider: () => new ObjectId().toString(),
     });
+    const userId = await mongoOptions.createUser(user);
+    await mongoOptions.addEmailVerificationToken(userId, 'john@doe.com', 'token');
   });
 
-  describe('setResetPassword', () => {
-    it('should change password', async () => {
-      const newPassword = 'newpass';
-      const userId = await databaseTests.database.createUser(user);
-      await delay(10);
-      await databaseTests.database.setResetPassword(userId, 'toto', newPassword);
-      const retUser = await databaseTests.database.findUserById(userId);
-      const services: any = retUser!.services;
-      expect(services.password.bcrypt).toBeTruthy();
-      expect(services.password.bcrypt).toEqual(newPassword);
-      expect((retUser as any).createdAt).not.toEqual((retUser as any).updatedAt);
+  it('should add a token', async () => {
+    const userId = await databaseTests.database.createUser(user);
+    await databaseTests.database.addEmailVerificationToken(userId, 'john@doe.com', 'token');
+    const retUser = await databaseTests.database.findUserById(userId);
+    const services: any = retUser!.services;
+    expect(services.email.verificationTokens.length).toEqual(1);
+    expect(services.email.verificationTokens[0].address).toEqual('john@doe.com');
+    expect(services.email.verificationTokens[0].token).toEqual('token');
+    expect(services.email.verificationTokens[0].when).toBeTruthy();
+  });
+});
+
+describe('addResetPasswordToken', () => {
+  // eslint-disable-next-line jest/expect-expect
+  it('should not convert id', async () => {
+    const mongoOptions = new Mongo(databaseTests.db, {
+      convertUserIdToMongoObjectId: false,
+      idProvider: () => new ObjectId().toString(),
     });
+    const userId = await mongoOptions.createUser(user);
+    await mongoOptions.addResetPasswordToken(userId, 'john@doe.com', 'token', 'reset');
   });
 
-  describe('setUserDeactivated', () => {
-    // eslint-disable-next-line jest/expect-expect
-    it('should not convert id', async () => {
-      const mongoOptions = new Mongo(databaseTests.db, {
-        convertUserIdToMongoObjectId: false,
-        idProvider: () => new ObjectId().toString(),
-      });
-      const userId = await mongoOptions.createUser(user);
-      await mongoOptions.setUserDeactivated(userId, true);
-    });
+  it('should add a token', async () => {
+    const userId = await databaseTests.database.createUser(user);
+    await databaseTests.database.addResetPasswordToken(userId, 'john@doe.com', 'token', 'reset');
+    const retUser = await databaseTests.database.findUserById(userId);
+    const services: any = retUser!.services;
+    expect(services.password.reset.length).toEqual(1);
+    expect(services.password.reset[0].address).toEqual('john@doe.com');
+    expect(services.password.reset[0].token).toEqual('token');
+    expect(services.password.reset[0].when).toBeTruthy();
+    expect(services.password.reset[0].reason).toEqual('reset');
+  });
+});
 
-    it('should deactivate user', async () => {
-      const userId = await databaseTests.database.createUser(user);
-      await databaseTests.database.setUserDeactivated(userId, true);
-      const retUser = await databaseTests.database.findUserById(userId);
-      expect(retUser!.deactivated).toBeTruthy();
-      expect((retUser as any).createdAt).not.toEqual((retUser as any).updatedAt);
+describe('setResetPassword', () => {
+  it('should change password', async () => {
+    const newPassword = 'newpass';
+    const userId = await databaseTests.database.createUser(user);
+    await delay(10);
+    await databaseTests.database.setResetPassword(userId, 'toto', newPassword);
+    const retUser = await databaseTests.database.findUserById(userId);
+    const services: any = retUser!.services;
+    expect(services.password.bcrypt).toBeTruthy();
+    expect(services.password.bcrypt).toEqual(newPassword);
+    expect((retUser as any).createdAt).not.toEqual((retUser as any).updatedAt);
+  });
+});
+
+describe('setUserDeactivated', () => {
+  // eslint-disable-next-line jest/expect-expect
+  it('should not convert id', async () => {
+    const mongoOptions = new Mongo(databaseTests.db, {
+      convertUserIdToMongoObjectId: false,
+      idProvider: () => new ObjectId().toString(),
     });
+    const userId = await mongoOptions.createUser(user);
+    await mongoOptions.setUserDeactivated(userId, true);
+  });
+
+  it('should deactivate user', async () => {
+    const userId = await databaseTests.database.createUser(user);
+    await databaseTests.database.setUserDeactivated(userId, true);
+    const retUser = await databaseTests.database.findUserById(userId);
+    expect(retUser!.deactivated).toBeTruthy();
+    expect((retUser as any).createdAt).not.toEqual((retUser as any).updatedAt);
   });
 });

--- a/packages/database-mongo/src/mongo.ts
+++ b/packages/database-mongo/src/mongo.ts
@@ -365,8 +365,9 @@ export class Mongo implements DatabaseInterface {
   }
 
   public async removeAllPasswordResetTokens(userId: string): Promise<void> {
-    await this.sessionCollection.update(
-      { userId },
+    const id = this.options.convertUserIdToMongoObjectId ? toMongoID(userId) : userId;
+    await this.collection.update(
+      { _id: id },
       {
         $set: {
           'services.email.verificationTokens': [],

--- a/packages/database-mongo/src/mongo.ts
+++ b/packages/database-mongo/src/mongo.ts
@@ -364,6 +364,18 @@ export class Mongo implements DatabaseInterface {
     );
   }
 
+  public async removeAllPasswordResetTokens(userId: string): Promise<void> {
+    await this.sessionCollection.update(
+      { userId },
+      {
+        $set: {
+          'services.email.verificationTokens': [],
+        },
+      },
+      { multi: true }
+    );
+  }
+
   public async findSessionByToken(token: string): Promise<Session | null> {
     const session = await this.sessionCollection.findOne({ token });
     if (session) {

--- a/packages/database-mongo/src/mongo.ts
+++ b/packages/database-mongo/src/mongo.ts
@@ -369,8 +369,8 @@ export class Mongo implements DatabaseInterface {
     await this.collection.update(
       { _id: id },
       {
-        $set: {
-          'services.password.reset': [],
+        $unset: {
+          'services.password.reset': '',
         },
       }
     );

--- a/packages/database-mongo/src/mongo.ts
+++ b/packages/database-mongo/src/mongo.ts
@@ -371,8 +371,7 @@ export class Mongo implements DatabaseInterface {
         $set: {
           'services.email.verificationTokens': [],
         },
-      },
-      { multi: true }
+      }
     );
   }
 

--- a/packages/database-mongo/src/mongo.ts
+++ b/packages/database-mongo/src/mongo.ts
@@ -364,7 +364,7 @@ export class Mongo implements DatabaseInterface {
     );
   }
 
-  public async removeAllPasswordResetTokens(userId: string): Promise<void> {
+  public async removeAllResetPasswordTokens(userId: string): Promise<void> {
     const id = this.options.convertUserIdToMongoObjectId ? toMongoID(userId) : userId;
     await this.collection.update(
       { _id: id },

--- a/packages/database-mongo/src/mongo.ts
+++ b/packages/database-mongo/src/mongo.ts
@@ -370,7 +370,7 @@ export class Mongo implements DatabaseInterface {
       { _id: id },
       {
         $set: {
-          'services.email.verificationTokens': [],
+          'services.password.reset': [],
         },
       }
     );

--- a/packages/database-typeorm/src/typeorm.ts
+++ b/packages/database-typeorm/src/typeorm.ts
@@ -343,7 +343,7 @@ export class AccountsTypeorm implements DatabaseInterface {
     );
   }
 
-  public async removeAllPasswordResetTokens(userId: string): Promise<void> {
+  public async removeAllResetPasswordTokens(userId: string): Promise<void> {
     await this.unsetService(userId, 'password.reset');
   }
 

--- a/packages/database-typeorm/src/typeorm.ts
+++ b/packages/database-typeorm/src/typeorm.ts
@@ -343,6 +343,10 @@ export class AccountsTypeorm implements DatabaseInterface {
     );
   }
 
+  public async removeAllPasswordResetTokens(userId: string): Promise<void> {
+    await this.unsetService(userId, 'password.reset');
+  }
+
   public async setUserDeactivated(userId: string, deactivated: boolean): Promise<void> {
     const user = await this.findUserById(userId);
     if (user) {

--- a/packages/password/__tests__/__snapshots__/accounts-password.ts.snap
+++ b/packages/password/__tests__/__snapshots__/accounts-password.ts.snap
@@ -14,7 +14,7 @@ Array [
 ]
 `;
 
-exports[`AccountsPassword changePassword, invalidate all sessions and remove all reset password tokens from user storage call removeAllPasswordResetTokens 1`] = `
+exports[`AccountsPassword changePassword, invalidate all sessions and remove all reset password tokens from user storage call removeAllResetPasswordTokens 1`] = `
 Array [
   undefined,
 ]

--- a/packages/password/__tests__/__snapshots__/accounts-password.ts.snap
+++ b/packages/password/__tests__/__snapshots__/accounts-password.ts.snap
@@ -8,7 +8,13 @@ Array [
 ]
 `;
 
-exports[`AccountsPassword changePassword and invalidate all sessions call invalidateAllSessions 1`] = `
+exports[`AccountsPassword changePassword, invalidate all sessions and remove all reset password tokens from user storage call invalidateAllSessions 1`] = `
+Array [
+  undefined,
+]
+`;
+
+exports[`AccountsPassword changePassword, invalidate all sessions and remove all reset password tokens from user storage call removeAllPasswordResetTokens 1`] = `
 Array [
   undefined,
 ]

--- a/packages/password/__tests__/accounts-password.ts
+++ b/packages/password/__tests__/accounts-password.ts
@@ -369,11 +369,13 @@ describe('AccountsPassword', () => {
       const findUserById = jest.fn(() => Promise.resolve(validUser));
       const invalidateAllSessions = jest.fn(() => Promise.resolve());
       const findPasswordHash = jest.fn(() => Promise.resolve());
+      const removeAllPasswordResetTokens = jest.fn(() => Promise.resolve());
       tmpAccountsPassword.setStore({
         setPassword,
         findUserById,
         findPasswordHash,
         invalidateAllSessions,
+        removeAllPasswordResetTokens,
       } as any);
       const prepareMail = jest.fn(() => Promise.resolve());
       const sanitizeUser = jest.fn(() => Promise.resolve());
@@ -397,10 +399,12 @@ describe('AccountsPassword', () => {
       const userId = 'id';
       const setPassword = jest.fn(() => Promise.resolve('user'));
       const findUserById = jest.fn(() => Promise.resolve(validUser));
-      password.setStore({ setPassword, findUserById } as any);
+      const removeAllPasswordResetTokens = jest.fn(() => Promise.resolve());
+      password.setStore({ setPassword, findUserById, removeAllPasswordResetTokens } as any);
       const prepareMail = jest.fn(() => Promise.resolve());
       const sanitizeUser = jest.fn(() => Promise.resolve());
       const sendMail = jest.fn(() => Promise.resolve());
+
       password.server = {
         ...server,
         prepareMail,

--- a/packages/password/__tests__/accounts-password.ts
+++ b/packages/password/__tests__/accounts-password.ts
@@ -423,7 +423,7 @@ describe('AccountsPassword', () => {
         .spyOn(tmpAccountsPassword, 'passwordAuthenticator' as any)
         .mockImplementation(() => Promise.resolve(validUser));
       await tmpAccountsPassword.changePassword(userId, 'old-password', 'new-password');
-      expect(invalidateAllSessions.mock.calls[0]).toMatchSnapshot();
+      expect(removeAllPasswordResetTokens.mock.calls[0]).toMatchSnapshot();
       (tmpAccountsPassword as any).passwordAuthenticator.mockRestore();
     });
 

--- a/packages/password/__tests__/accounts-password.ts
+++ b/packages/password/__tests__/accounts-password.ts
@@ -369,13 +369,13 @@ describe('AccountsPassword', () => {
       const findUserById = jest.fn(() => Promise.resolve(validUser));
       const invalidateAllSessions = jest.fn(() => Promise.resolve());
       const findPasswordHash = jest.fn(() => Promise.resolve());
-      const removeAllPasswordResetTokens = jest.fn(() => Promise.resolve());
+      const removeAllResetPasswordTokens = jest.fn(() => Promise.resolve());
       tmpAccountsPassword.setStore({
         setPassword,
         findUserById,
         findPasswordHash,
         invalidateAllSessions,
-        removeAllPasswordResetTokens,
+        removeAllResetPasswordTokens,
       } as any);
       const prepareMail = jest.fn(() => Promise.resolve());
       const sanitizeUser = jest.fn(() => Promise.resolve());
@@ -395,19 +395,19 @@ describe('AccountsPassword', () => {
       (tmpAccountsPassword as any).passwordAuthenticator.mockRestore();
     });
 
-    it('call removeAllPasswordResetTokens', async () => {
+    it('call removeAllResetPasswordTokens', async () => {
       const userId = 'id';
       const setPassword = jest.fn(() => Promise.resolve('user'));
       const findUserById = jest.fn(() => Promise.resolve(validUser));
       const invalidateAllSessions = jest.fn(() => Promise.resolve());
       const findPasswordHash = jest.fn(() => Promise.resolve());
-      const removeAllPasswordResetTokens = jest.fn(() => Promise.resolve());
+      const removeAllResetPasswordTokens = jest.fn(() => Promise.resolve());
       tmpAccountsPassword.setStore({
         setPassword,
         findUserById,
         findPasswordHash,
         invalidateAllSessions,
-        removeAllPasswordResetTokens,
+        removeAllResetPasswordTokens,
       } as any);
       const prepareMail = jest.fn(() => Promise.resolve());
       const sanitizeUser = jest.fn(() => Promise.resolve());
@@ -423,7 +423,7 @@ describe('AccountsPassword', () => {
         .spyOn(tmpAccountsPassword, 'passwordAuthenticator' as any)
         .mockImplementation(() => Promise.resolve(validUser));
       await tmpAccountsPassword.changePassword(userId, 'old-password', 'new-password');
-      expect(removeAllPasswordResetTokens.mock.calls[0]).toMatchSnapshot();
+      expect(removeAllResetPasswordTokens.mock.calls[0]).toMatchSnapshot();
       (tmpAccountsPassword as any).passwordAuthenticator.mockRestore();
     });
 
@@ -431,8 +431,8 @@ describe('AccountsPassword', () => {
       const userId = 'id';
       const setPassword = jest.fn(() => Promise.resolve('user'));
       const findUserById = jest.fn(() => Promise.resolve(validUser));
-      const removeAllPasswordResetTokens = jest.fn(() => Promise.resolve());
-      password.setStore({ setPassword, findUserById, removeAllPasswordResetTokens } as any);
+      const removeAllResetPasswordTokens = jest.fn(() => Promise.resolve());
+      password.setStore({ setPassword, findUserById, removeAllResetPasswordTokens } as any);
       const prepareMail = jest.fn(() => Promise.resolve());
       const sanitizeUser = jest.fn(() => Promise.resolve());
       const sendMail = jest.fn(() => Promise.resolve());

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -86,7 +86,7 @@ export interface AccountsPasswordOptions {
   invalidateAllSessionsAfterPasswordChanged?: boolean;
   /**
    * Will remove all password reset tokens from the db after a password has been changed.
-   * Default to false.
+   * Default to true.
    */
   removeAllResetPasswordTokensAfterPasswordChanged?: boolean;
   /**

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -85,13 +85,12 @@ export interface AccountsPasswordOptions {
    */
   invalidateAllSessionsAfterPasswordChanged?: boolean;
   /**
-   * Will automatically send a verification email after signup.
+   * Will remove all password reset tokens from the db after a password has been changed.
    * Default to false.
    */
-
   removeAllPasswordResetTokensAfterPasswordChanged?: boolean;
   /**
-   * Will remove all password reset tokens from the db after a password has been changed.
+   * Will automatically send a verification email after signup.
    * Default to false.
    */
   sendVerificationEmailAfterSignup?: boolean;

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -88,7 +88,7 @@ export interface AccountsPasswordOptions {
    * Will remove all password reset tokens from the db after a password has been changed.
    * Default to false.
    */
-  removeAllPasswordResetTokensAfterPasswordChanged?: boolean;
+  removeAllResetPasswordTokensAfterPasswordChanged?: boolean;
   /**
    * Will automatically send a verification email after signup.
    * Default to false.
@@ -141,7 +141,7 @@ const defaultOptions = {
   returnTokensAfterResetPassword: false,
   invalidateAllSessionsAfterPasswordReset: true,
   invalidateAllSessionsAfterPasswordChanged: false,
-  removeAllPasswordResetTokensAfterPasswordChanged: true,
+  removeAllResetPasswordTokensAfterPasswordChanged: true,
   errors,
   sendVerificationEmailAfterSignup: false,
   validateEmail(email?: string): boolean {
@@ -427,8 +427,8 @@ export default class AccountsPassword implements AuthenticationService {
       await this.db.invalidateAllSessions(user.id);
     }
 
-    if (this.options.removeAllPasswordResetTokensAfterPasswordChanged) {
-      await this.db.removeAllPasswordResetTokens(user.id);
+    if (this.options.removeAllResetPasswordTokensAfterPasswordChanged) {
+      await this.db.removeAllResetPasswordTokens(user.id);
     }
 
     if (this.options.notifyUserAfterPasswordChanged) {

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -88,6 +88,12 @@ export interface AccountsPasswordOptions {
    * Will automatically send a verification email after signup.
    * Default to false.
    */
+
+  removeAllPasswordResetTokensAfterPasswordChanged?: boolean;
+  /**
+   * Will remove all password reset tokens from the db after a password has been changed.
+   * Default to false.
+   */
   sendVerificationEmailAfterSignup?: boolean;
   /**
    * Function that will validate the user object during `createUser`.
@@ -136,6 +142,7 @@ const defaultOptions = {
   returnTokensAfterResetPassword: false,
   invalidateAllSessionsAfterPasswordReset: true,
   invalidateAllSessionsAfterPasswordChanged: false,
+  removeAllPasswordResetTokensAfterPasswordChanged: true,
   errors,
   sendVerificationEmailAfterSignup: false,
   validateEmail(email?: string): boolean {
@@ -419,6 +426,10 @@ export default class AccountsPassword implements AuthenticationService {
 
     if (this.options.invalidateAllSessionsAfterPasswordChanged) {
       await this.db.invalidateAllSessions(user.id);
+    }
+
+    if (this.options.removeAllPasswordResetTokensAfterPasswordChanged) {
+      await this.db.removeAllPasswordResetTokens(user.id);
     }
 
     if (this.options.notifyUserAfterPasswordChanged) {

--- a/packages/types/src/types/services/password/database-interface.ts
+++ b/packages/types/src/types/services/password/database-interface.ts
@@ -37,5 +37,5 @@ export interface DatabaseInterfaceServicePassword {
 
   addEmailVerificationToken(userId: string, email: string, token: string): Promise<void>;
 
-  removeAllPasswordResetTokens(userId: string): Promise<void>;
+  removeAllReserPasswordTokens(userId: string): Promise<void>;
 }

--- a/packages/types/src/types/services/password/database-interface.ts
+++ b/packages/types/src/types/services/password/database-interface.ts
@@ -37,5 +37,5 @@ export interface DatabaseInterfaceServicePassword {
 
   addEmailVerificationToken(userId: string, email: string, token: string): Promise<void>;
 
-  removeAllReserPasswordTokens(userId: string): Promise<void>;
+  removeAllResetPasswordTokens(userId: string): Promise<void>;
 }

--- a/packages/types/src/types/services/password/database-interface.ts
+++ b/packages/types/src/types/services/password/database-interface.ts
@@ -36,4 +36,6 @@ export interface DatabaseInterfaceServicePassword {
   verifyEmail(userId: string, email: string): Promise<void>;
 
   addEmailVerificationToken(userId: string, email: string, token: string): Promise<void>;
+
+  removeAllPasswordResetTokens(userId: string): Promise<void>;
 }


### PR DESCRIPTION
Adding the method `removeAllPasswordResetTokens` to the `password`  package. This method is called within the `changePassword` method. It removes all password reset tokens from the user storage.