### PR TITLE
feat: add new `useInternalUserObjectSanitizer` option

### DIFF
--- a/packages/express-session/src/index.ts
+++ b/packages/express-session/src/index.ts
@@ -9,7 +9,7 @@ import { getUserAgent } from './utils/get-user-agent';
 export interface AccountsSessionOptions {
   user?: {
     name: string;
-    resolve?: (tokens: Tokens, request: Request) => User | Promise<User>;
+    resolve?: (tokens: Tokens, request: Request, rawUser?: User) => User | Promise<User>;
   };
   name?: string;
 }
@@ -38,7 +38,7 @@ export class AccountsSession {
 
         if (tokens) {
           const user = this.options.user.resolve
-            ? await this.options.user.resolve(tokens, req)
+            ? await this.options.user.resolve(tokens, req, tokenResult?.user)
             : tokenResult?.user;
 
           // eslint-disable-next-line

--- a/packages/express-session/src/index.ts
+++ b/packages/express-session/src/index.ts
@@ -1,5 +1,5 @@
 import { AccountsServer } from '@accounts/server';
-import { Tokens, User } from '@accounts/types';
+import { Tokens, User, LoginResult } from '@accounts/types';
 import { Request, Response, NextFunction } from 'express';
 import * as requestIp from 'request-ip';
 import { merge } from 'lodash';
@@ -9,7 +9,7 @@ import { getUserAgent } from './utils/get-user-agent';
 export interface AccountsSessionOptions {
   user?: {
     name: string;
-    resolve: (tokens: Tokens) => User | Promise<User>;
+    resolve?: (tokens: Tokens, request: Request) => User | Promise<User>;
   };
   name?: string;
 }
@@ -23,10 +23,7 @@ export class AccountsSession {
         name: 'accounts-js-tokens',
         user: {
           name: 'user',
-          resolve: async (tokens: Tokens) => {
-            const user = await accountsServer.resumeSession(tokens.accessToken);
-            return user;
-          },
+          resolve: null,
         },
       },
       options
@@ -36,11 +33,13 @@ export class AccountsSession {
   public middleware() {
     return async (req: Request, res: Response, next: NextFunction) => {
       try {
-        await this.renew(req);
-
+        const tokenResult = await this.renew(req);
         const tokens = this.get(req);
+
         if (tokens) {
-          const user = await this.options.user.resolve(tokens);
+          const user = this.options.user.resolve
+            ? await this.options.user.resolve(tokens, req)
+            : tokenResult?.user;
 
           // eslint-disable-next-line
           // @ts-ignore
@@ -83,7 +82,7 @@ export class AccountsSession {
     }
   }
 
-  public async renew(req: Request): Promise<Tokens | undefined> {
+  public async renew(req: Request): Promise<LoginResult | undefined> {
     const tokens = this.get(req);
 
     if (this.accountsServer && tokens && tokens.accessToken && tokens.refreshToken) {
@@ -95,7 +94,7 @@ export class AccountsSession {
 
       this.set(req, result.tokens);
 
-      return result.tokens;
+      return result;
     }
   }
 

--- a/packages/server/src/accounts-server.ts
+++ b/packages/server/src/accounts-server.ts
@@ -381,7 +381,7 @@ Please set ambiguousErrorMessages to false to be able to use autologin.`
         }
 
         const tokens = this.createTokens({ token: newToken || sessionToken, userId: user.id });
-        await this.db.updateSession(session.id, infos, newToken);
+        this.db.updateSession(session.id, infos, newToken);
 
         const result = {
           sessionId: session.id,

--- a/packages/server/src/accounts-server.ts
+++ b/packages/server/src/accounts-server.ts
@@ -44,7 +44,6 @@ const defaultOptions = {
     },
   },
   emailTemplates,
-  userObjectSanitizer: (user: User) => user,
   sendMail,
   siteUrl: 'http://localhost:3000',
   createNewSessionTokenOnRefresh: false,
@@ -583,7 +582,11 @@ Please set ambiguousErrorMessages to false to be able to use autologin.`
   public sanitizeUser(user: User): User {
     const { userObjectSanitizer } = this.options;
 
-    return userObjectSanitizer(this.internalUserSanitizer(user), omit as any, pick as any);
+    if (userObjectSanitizer) {
+      return userObjectSanitizer(user, omit as any, pick as any);
+    }
+
+    return this.internalUserSanitizer(user);
   }
 
   private internalUserSanitizer(user: User): User {

--- a/packages/server/src/types/accounts-server-options.ts
+++ b/packages/server/src/types/accounts-server-options.ts
@@ -40,4 +40,9 @@ export interface AccountsServerOptions {
    * LoginResult data will be included into registration response.
    */
   enableAutologin?: boolean;
+  /**
+   * Set this false to `false` if you wish to skip internal user sanitazing method, and expose
+   * the original User object as-is.
+   */
+  useInternalUserObjectSanitizer?: boolean;
 }


### PR DESCRIPTION
- This might take up to 300ms, and if someone is using Accounts with express, it will run as part of the middleware.
Adding 300ms to something we don't really need the response of, is not needed.

- This PR also includes a fix for this issue: https://github.com/accounts-js/accounts/issues/933 

- Also, I pushed an optional fix for `express-session`. The `resolve` method there is not really mandatory, since we are running `renew`, which executes `refreshTokens` and eventually pulls `User` from the database, so we have the `user` already. So `resolve` could be optional! 