### PR TITLE
fix(graphql-client): fix add email mutation

### DIFF
--- a/packages/graphql-client/src/graphql-client.ts
+++ b/packages/graphql-client/src/graphql-client.ts
@@ -8,6 +8,7 @@ import {
 } from '@accounts/types';
 import { print } from 'graphql';
 import gql from 'graphql-tag';
+import { addEmailMutation } from './graphql/add-email.mutation';
 import { authenticateWithServiceMutation } from './graphql/authenticate-with-service.mutation';
 import { changePasswordMutation } from './graphql/change-password.mutation';
 import { createUserMutation } from './graphql/create-user.mutation';
@@ -141,7 +142,7 @@ export default class GraphQLClient implements TransportInterface {
    * @inheritDoc
    */
   public async addEmail(newEmail: string): Promise<void> {
-    return this.mutate(changePasswordMutation, 'addEmail', { newEmail });
+    return this.mutate(addEmailMutation, 'addEmail', { newEmail });
   }
 
   /**

--- a/packages/graphql-client/src/graphql/add-email.mutation.ts
+++ b/packages/graphql-client/src/graphql/add-email.mutation.ts
@@ -1,0 +1,7 @@
+import gql from 'graphql-tag';
+
+export const addEmailMutation = gql`
+  mutation addEmail($newEmail: String!) {
+    addEmail(newEmail: $newEmail)
+  }
+`;


### PR DESCRIPTION
This PR:

- fixes the addEmail feature which was incorrectly linked to changePassword in the graphql-client package
- adds  the missing addEmail mutation.
- includes a `verified` parameter on the mutation to allow users to specify if the new email they're adding should be marked as verified.
- Updates the following packages to take account of the new mutation: `client`, `client-password`, `graphql-api` and `graphql-client`
- adds some missing types that were flagged whilst running the tests