### PR TITLE
fix(graphql-client): reduce bundle size by importing only graphql subpackages

### DIFF
--- a/packages/graphql-client/package.json
+++ b/packages/graphql-client/package.json
@@ -34,5 +34,8 @@
     "@accounts/types": "^0.25.0",
     "graphql-tag": "^2.10.0",
     "tslib": "1.10.0"
+  },
+  "peerDependencies": {
+    "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
   }
 }

--- a/packages/graphql-client/src/GraphQLErrorList.ts
+++ b/packages/graphql-client/src/GraphQLErrorList.ts
@@ -1,4 +1,4 @@
-import { GraphQLError } from 'graphql';
+import { GraphQLError } from 'graphql/error/GraphQLError';
 
 export class GraphQLErrorList extends Error {
   public errors: readonly GraphQLError[];

--- a/packages/graphql-client/src/graphql-client.ts
+++ b/packages/graphql-client/src/graphql-client.ts
@@ -6,7 +6,7 @@ import {
   User,
   CreateUserResult,
 } from '@accounts/types';
-import { print } from 'graphql';
+import { print } from 'graphql/language';
 import gql from 'graphql-tag';
 import { addEmailMutation } from './graphql/add-email.mutation';
 import { authenticateWithServiceMutation } from './graphql/authenticate-with-service.mutation';


### PR DESCRIPTION
closes: https://github.com/accounts-js/accounts/issues/938