### PR TITLE
feat: create User generic to allow better typechecking

### DIFF
--- a/examples/graphql-server-typeorm-postgres/src/index.ts
+++ b/examples/graphql-server-typeorm-postgres/src/index.ts
@@ -4,7 +4,7 @@ import { mergeTypeDefs, mergeResolvers } from 'graphql-toolkit';
 import { AccountsModule } from '@accounts/graphql-api';
 import { AccountsPassword } from '@accounts/password';
 import { AccountsServer } from '@accounts/server';
-import { AccountsTypeorm } from '@accounts/typeorm';
+import { AccountsTypeorm, User } from '@accounts/typeorm';
 import { connect } from './connect';
 
 export const createAccounts = async () => {
@@ -12,7 +12,7 @@ export const createAccounts = async () => {
   // Like, fix this man!
   const tokenSecret = 'process.env.ACCOUNTS_SECRET' || 'change this in .env';
   const db = new AccountsTypeorm({ connection, cache: 1000 });
-  const password = new AccountsPassword();
+  const password = new AccountsPassword<User>();
   const accountsServer = new AccountsServer(
     {
       db,

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -159,24 +159,25 @@ const defaultOptions = {
   verifyPassword,
 };
 
-export default class AccountsPassword implements AuthenticationService {
+export default class AccountsPassword<CustomUser extends User = User>
+  implements AuthenticationService {
   public serviceName = 'password';
   public server!: AccountsServer;
   public twoFactor: TwoFactor;
   private options: AccountsPasswordOptions & typeof defaultOptions;
-  private db!: DatabaseInterface;
+  private db!: DatabaseInterface<CustomUser>;
 
   constructor(options: AccountsPasswordOptions = {}) {
     this.options = { ...defaultOptions, ...options };
     this.twoFactor = new TwoFactor(options.twoFactor);
   }
 
-  public setStore(store: DatabaseInterface) {
+  public setStore(store: DatabaseInterface<CustomUser>) {
     this.db = store;
     this.twoFactor.setStore(store);
   }
 
-  public async authenticate(params: LoginUserPasswordService): Promise<User> {
+  public async authenticate(params: LoginUserPasswordService): Promise<CustomUser> {
     const { user, password, code } = params;
     if (!user || !password) {
       throw new AccountsJsError(
@@ -203,7 +204,7 @@ export default class AccountsPassword implements AuthenticationService {
    * @param {string} email - User email.
    * @returns {Promise<Object>} - Return a user or null if not found.
    */
-  public findUserByEmail(email: string): Promise<User | null> {
+  public findUserByEmail(email: string): Promise<CustomUser | null> {
     return this.db.findUserByEmail(email);
   }
 
@@ -212,7 +213,7 @@ export default class AccountsPassword implements AuthenticationService {
    * @param {string} username - User username.
    * @returns {Promise<Object>} - Return a user or null if not found.
    */
-  public findUserByUsername(username: string): Promise<User | null> {
+  public findUserByUsername(username: string): Promise<CustomUser | null> {
     return this.db.findUserByUsername(username);
   }
 
@@ -666,12 +667,12 @@ export default class AccountsPassword implements AuthenticationService {
   private async passwordAuthenticator(
     user: string | LoginUserIdentity,
     password: string
-  ): Promise<User> {
+  ): Promise<CustomUser> {
     const { username, email, id } = isString(user)
       ? this.toUsernameAndEmail({ user })
       : this.toUsernameAndEmail({ ...user });
 
-    let foundUser: User | null = null;
+    let foundUser: CustomUser | null = null;
 
     if (id) {
       // this._validateLoginWithField('id', user);

--- a/packages/server/src/accounts-server.ts
+++ b/packages/server/src/accounts-server.ts
@@ -51,13 +51,16 @@ const defaultOptions = {
   useInternalUserObjectSanitizer: true,
 };
 
-export class AccountsServer {
-  public options: AccountsServerOptions & typeof defaultOptions;
-  private services: { [key: string]: AuthenticationService };
-  private db: DatabaseInterface;
+export class AccountsServer<CustomUser extends User = User> {
+  public options: AccountsServerOptions<CustomUser> & typeof defaultOptions;
+  private services: { [key: string]: AuthenticationService<CustomUser> };
+  private db: DatabaseInterface<CustomUser>;
   private hooks: Emittery;
 
-  constructor(options: AccountsServerOptions, services: { [key: string]: AuthenticationService }) {
+  constructor(
+    options: AccountsServerOptions<CustomUser>,
+    services: { [key: string]: AuthenticationService<CustomUser> }
+  ) {
     this.options = merge({ ...defaultOptions }, options);
     if (!this.options.db) {
       throw new Error('A database driver is required');
@@ -139,7 +142,7 @@ Please set ambiguousErrorMessages to false to be able to use autologin.`
         );
       }
 
-      const user: User | null = await this.services[serviceName].authenticate(params);
+      const user: CustomUser | null = await this.services[serviceName].authenticate(params);
       hooksInfo.user = user;
       if (!user) {
         throw new AccountsJsError(
@@ -186,7 +189,7 @@ Please set ambiguousErrorMessages to false to be able to use autologin.`
         );
       }
 
-      const user: User | null = await this.services[serviceName].authenticate(params);
+      const user: CustomUser | null = await this.services[serviceName].authenticate(params);
       hooksInfo.user = user;
       if (!user) {
         throw new AccountsJsError(
@@ -220,7 +223,10 @@ Please set ambiguousErrorMessages to false to be able to use autologin.`
    * @param {ConnectionInformations} infos - User connection informations.
    * @returns {Promise<LoginResult>} - Session id and tokens.
    */
-  public async loginWithUser(user: User, infos: ConnectionInformations): Promise<LoginResult> {
+  public async loginWithUser(
+    user: CustomUser,
+    infos: ConnectionInformations
+  ): Promise<LoginResult> {
     const token = await this.createSessionToken(user);
     const sessionId = await this.db.createSession(user.id, token, infos);
 
@@ -465,7 +471,7 @@ Please set ambiguousErrorMessages to false to be able to use autologin.`
   /**
    * @throws {@link ResumeSessionErrors}
    */
-  public async resumeSession(accessToken: string): Promise<User> {
+  public async resumeSession(accessToken: string): Promise<CustomUser> {
     try {
       const session: Session = await this.findSessionByAccessToken(accessToken);
 
@@ -545,7 +551,7 @@ Please set ambiguousErrorMessages to false to be able to use autologin.`
    * @param {string} userId - User id.
    * @returns {Promise<Object>} - Return a user or null if not found.
    */
-  public findUserById(userId: string): Promise<User | null> {
+  public findUserById(userId: string): Promise<CustomUser | null> {
     return this.db.findUserById(userId);
   }
 
@@ -570,7 +576,7 @@ Please set ambiguousErrorMessages to false to be able to use autologin.`
   public prepareMail(
     to: string,
     token: string,
-    user: User,
+    user: CustomUser,
     pathFragment: string,
     emailTemplate: EmailTemplateType,
     from: string
@@ -581,7 +587,7 @@ Please set ambiguousErrorMessages to false to be able to use autologin.`
     return this.defaultPrepareEmail(to, token, user, pathFragment, emailTemplate, from);
   }
 
-  public sanitizeUser(user: User): User {
+  public sanitizeUser(user: CustomUser): CustomUser {
     const { userObjectSanitizer } = this.options;
     const baseUser = this.options.useInternalUserObjectSanitizer
       ? this.internalUserSanitizer(user)
@@ -590,14 +596,14 @@ Please set ambiguousErrorMessages to false to be able to use autologin.`
     return userObjectSanitizer(baseUser, omit as any, pick as any);
   }
 
-  private internalUserSanitizer(user: User): User {
+  private internalUserSanitizer(user: CustomUser): CustomUser {
     return omit(user, ['services']) as any;
   }
 
   private defaultPrepareEmail(
     to: string,
     token: string,
-    user: User,
+    user: CustomUser,
     pathFragment: string,
     emailTemplate: EmailTemplateType,
     from: string
@@ -617,7 +623,7 @@ Please set ambiguousErrorMessages to false to be able to use autologin.`
     return `${siteUrl}/${pathFragment}/${token}`;
   }
 
-  private async createSessionToken(user: User): Promise<string> {
+  private async createSessionToken(user: CustomUser): Promise<string> {
     return this.options.tokenCreator
       ? this.options.tokenCreator.createToken(user)
       : generateRandomToken();

--- a/packages/server/src/types/accounts-server-options.ts
+++ b/packages/server/src/types/accounts-server-options.ts
@@ -7,12 +7,12 @@ import { PrepareMailFunction } from './prepare-mail-function';
 import { SendMailType } from './send-mail-type';
 import { TokenCreator } from './token-creator';
 
-export interface AccountsServerOptions {
+export interface AccountsServerOptions<CustomUser extends User = User> {
   /**
    * Return ambiguous error messages from login failures to prevent user enumeration. Defaults to true.
    */
   ambiguousErrorMessages?: boolean;
-  db?: DatabaseInterface;
+  db?: DatabaseInterface<CustomUser>;
   tokenSecret:
     | string
     | {

--- a/packages/types/src/types/authentication-service.ts
+++ b/packages/types/src/types/authentication-service.ts
@@ -4,9 +4,9 @@ import { DatabaseInterface } from './database-interface';
 // TODO : Fix circular dependency for better type checking
 // import AccountsServer from '@accounts/server';
 
-export interface AuthenticationService {
+export interface AuthenticationService<CustomUser extends User = User> {
   server: any;
   serviceName: string;
   setStore(store: DatabaseInterface): void;
-  authenticate(params: any): Promise<User | null>;
+  authenticate(params: any): Promise<CustomUser | null>;
 }

--- a/packages/types/src/types/database-interface.ts
+++ b/packages/types/src/types/database-interface.ts
@@ -3,17 +3,17 @@ import { CreateUser } from './create-user';
 import { DatabaseInterfaceSessions } from './session/database-interface';
 import { DatabaseInterfaceServicePassword } from './services/password/database-interface';
 
-export interface DatabaseInterface
+export interface DatabaseInterface<CustomUser extends User = User>
   extends DatabaseInterfaceSessions,
-    DatabaseInterfaceServicePassword {
+    DatabaseInterfaceServicePassword<CustomUser> {
   // Find user by identity fields
-  findUserById(userId: string): Promise<User | null>;
+  findUserById(userId: string): Promise<CustomUser | null>;
 
   // Create and update users
   createUser(user: CreateUser): Promise<string>;
 
   // Auth services related operations
-  findUserByServiceId(serviceName: string, serviceId: string): Promise<User | null>;
+  findUserByServiceId(serviceName: string, serviceId: string): Promise<CustomUser | null>;
 
   setService(userId: string, serviceName: string, data: object): Promise<void>;
 

--- a/packages/types/src/types/services/password/database-interface.ts
+++ b/packages/types/src/types/services/password/database-interface.ts
@@ -1,13 +1,13 @@
 import { User } from '../../user';
 
-export interface DatabaseInterfaceServicePassword {
-  findUserByEmail(email: string): Promise<User | null>;
+export interface DatabaseInterfaceServicePassword<CustomUser extends User = User> {
+  findUserByEmail(email: string): Promise<CustomUser | null>;
 
-  findUserByUsername(username: string): Promise<User | null>;
+  findUserByUsername(username: string): Promise<CustomUser | null>;
 
-  findUserByResetPasswordToken(token: string): Promise<User | null>;
+  findUserByResetPasswordToken(token: string): Promise<CustomUser | null>;
 
-  findUserByEmailVerificationToken(token: string): Promise<User | null>;
+  findUserByEmailVerificationToken(token: string): Promise<CustomUser | null>;
 
   findPasswordHash(userId: string): Promise<string | null>;
 


### PR DESCRIPTION
The goal is to allow you to pass your custom user type when you call the accounts-js functions manually server side

that way you can do:

```ts
interface MyUser extends User {
  firstName: string
}

const accountsServer = new AccountsServer<MyUser>({ ... }),

const user = await accountsServer.findUserById('id');
// user will now be of type `MyUser` instead of `User`
```