### PR TITLE
feat(graphql-client): load user data after login/registration when using @accounts/graphql-client

### DIFF
--- a/packages/graphql-client/src/graphql-client.ts
+++ b/packages/graphql-client/src/graphql-client.ts
@@ -63,7 +63,7 @@ export default class GraphQLClient implements TransportInterface {
    * @memberof GraphQLClient
    */
   public async createUser(user: CreateUser): Promise<CreateUserResult> {
-    return this.mutate(createUserMutation, 'createUser', { user });
+    return this.mutate(createUserMutation(this.options.userFieldsFragment), 'createUser', { user });
   }
 
   /**
@@ -86,7 +86,7 @@ export default class GraphQLClient implements TransportInterface {
     service: string,
     authenticateParams: AuthenticateParams
   ): Promise<LoginResult> {
-    return this.mutate(loginWithServiceMutation, 'authenticate', {
+    return this.mutate(loginWithServiceMutation(this.options.userFieldsFragment), 'authenticate', {
       serviceName: service,
       params: authenticateParams,
     });

--- a/packages/graphql-client/src/graphql/create-user.mutation.ts
+++ b/packages/graphql-client/src/graphql/create-user.mutation.ts
@@ -1,6 +1,8 @@
 import gql from 'graphql-tag';
 
-export const createUserMutation = gql`
+export const createUserMutation = (userFieldsFragment: any) => gql`
+  ${userFieldsFragment}
+
   mutation createUser($user: CreateUserInput!) {
     createUser(user: $user) {
       userId
@@ -9,6 +11,9 @@ export const createUserMutation = gql`
         tokens {
           refreshToken
           accessToken
+        }
+        user {
+          ...userFields
         }
       }
     }

--- a/packages/graphql-client/src/graphql/login-with-service.mutation.ts
+++ b/packages/graphql-client/src/graphql/login-with-service.mutation.ts
@@ -1,12 +1,17 @@
 import gql from 'graphql-tag';
 
-export const loginWithServiceMutation = gql`
+export const loginWithServiceMutation = (userFieldsFragment: any) => gql`
+  ${userFieldsFragment}
+
   mutation($serviceName: String!, $params: AuthenticateParamsInput!) {
     authenticate(serviceName: $serviceName, params: $params) {
       sessionId
       tokens {
         refreshToken
         accessToken
+      }
+      user {
+        ...userFields
       }
     }
   }


### PR DESCRIPTION
completes what i did in https://github.com/accounts-js/accounts/pull/894

I forgot there about those who are using accounts accounts client with graphql transport 🙊(now we do). So graphql-client's `createUser` and `authenticate` mutations responses will also contain user data => it will be available when using accounts `client` and/or `client-password` 