### PR TITLE
feat(mongo): add missing indexes for the password service

### DIFF
--- a/packages/database-mongo/src/mongo.ts
+++ b/packages/database-mongo/src/mongo.ts
@@ -70,6 +70,15 @@ export class Mongo implements DatabaseInterface {
       unique: true,
       sparse: true,
     });
+    // Index related to the password service
+    await this.collection.createIndex('services.email.verificationTokens.token', {
+      ...options,
+      sparse: true,
+    });
+    await this.collection.createIndex('services.password.reset.token', {
+      ...options,
+      sparse: true,
+    });
   }
 
   public async createUser({


### PR DESCRIPTION
The following indexes where missing:
- reset password token
- verify email token