### PR TITLE
chore(deps): remove dependency request-promise from packages/oauth

### DIFF
--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -19,7 +19,6 @@
   },
   "dependencies": {
     "@accounts/types": "^0.25.4",
-    "request-promise": "^4.2.5",
     "tslib": "1.11.2"
   },
   "devDependencies": {


### PR DESCRIPTION
I will open another PR for removing it specificallly from oauth-instagram package. should be easy to repalce like with twitter package using this.oauth instead!

This would partially fix #937