### PR TITLE
feat(graphql-api): ability to extend connection information

### DIFF
--- a/packages/graphql-api/__tests__/modules/accounts-password/resolvers/mutation.ts
+++ b/packages/graphql-api/__tests__/modules/accounts-password/resolvers/mutation.ts
@@ -23,8 +23,10 @@ describe('accounts-password resolvers mutation', () => {
   };
   let injector: { get: jest.Mock };
   const user = { id: 'idTest' };
-  const ip = 'ipTest';
-  const userAgent = 'userAgentTest';
+  const infos = {
+    ip: 'ipTest',
+    userAgent: 'userAgentTest',
+  };
 
   beforeEach(() => {
     injector = {
@@ -188,16 +190,13 @@ describe('accounts-password resolvers mutation', () => {
       const response = await Mutation.createUser!(
         {},
         { user: createUserInput },
-        { injector } as any,
+        { injector, infos } as any,
         {} as any
       );
       expect(injector.get).toHaveBeenCalledWith(AccountsPassword);
       expect(injector.get).toHaveBeenCalledWith(AccountsServer);
       expect(accountsPasswordLocalMock.createUser).toHaveBeenCalledWith(createUserInput);
-      expect(accountsServerLocalMock.loginWithUser).toHaveBeenCalledWith(
-        createdUser,
-        expect.any(Object)
-      );
+      expect(accountsServerLocalMock.loginWithUser).toHaveBeenCalledWith(createdUser, infos);
       expect(response?.loginResult).not.toBeNull();
       expect(response?.loginResult!.user).toEqual(createdUser);
       expect(response?.loginResult!.tokens?.accessToken).toEqual('accessToken');
@@ -251,14 +250,11 @@ describe('accounts-password resolvers mutation', () => {
       await Mutation.resetPassword!(
         {},
         { token, newPassword } as any,
-        { injector, ip, userAgent } as any,
+        { injector, infos } as any,
         {} as any
       );
       expect(injector.get).toHaveBeenCalledWith(AccountsPassword);
-      expect(accountsPasswordMock.resetPassword).toHaveBeenCalledWith(token, newPassword, {
-        ip,
-        userAgent,
-      });
+      expect(accountsPasswordMock.resetPassword).toHaveBeenCalledWith(token, newPassword, infos);
     });
   });
 

--- a/packages/graphql-api/__tests__/modules/accounts/resolvers/mutation.ts
+++ b/packages/graphql-api/__tests__/modules/accounts/resolvers/mutation.ts
@@ -14,8 +14,10 @@ describe('accounts resolvers mutation', () => {
     get: jest.fn(() => accountsServerMock),
   };
   const authToken = 'authTokenTest';
-  const ip = 'ipTest';
-  const userAgent = 'userAgentTest';
+  const infos = {
+    ip: 'ipTest',
+    userAgent: 'userAgentTest',
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -29,28 +31,26 @@ describe('accounts resolvers mutation', () => {
       await Mutation.authenticate!(
         {},
         { serviceName, params } as any,
-        { injector, ip, userAgent } as any,
+        { injector, infos } as any,
         {} as any
       );
       expect(injector.get).toHaveBeenCalledWith(AccountsServer);
-      expect(accountsServerMock.loginWithService).toHaveBeenCalledWith(serviceName, params, {
-        ip,
-        userAgent,
-      });
+      expect(accountsServerMock.loginWithService).toHaveBeenCalledWith(serviceName, params, infos);
     });
 
     it('should call authenticateWithService', async () => {
       await Mutation.verifyAuthentication!(
         {},
         { serviceName, params } as any,
-        { injector, ip, userAgent } as any,
+        { injector, infos } as any,
         {} as any
       );
       expect(injector.get).toHaveBeenCalledWith(AccountsServer);
-      expect(accountsServerMock.authenticateWithService).toHaveBeenCalledWith(serviceName, params, {
-        ip,
-        userAgent,
-      });
+      expect(accountsServerMock.authenticateWithService).toHaveBeenCalledWith(
+        serviceName,
+        params,
+        infos
+      );
     });
   });
 
@@ -62,15 +62,11 @@ describe('accounts resolvers mutation', () => {
       await Mutation.impersonate!(
         {},
         { accessToken, username } as any,
-        { injector, ip, userAgent } as any,
+        { injector, infos } as any,
         {} as any
       );
       expect(injector.get).toHaveBeenCalledWith(AccountsServer);
-      expect(accountsServerMock.impersonate).toHaveBeenCalledWith(
-        accessToken,
-        { username },
-        { ip, userAgent }
-      );
+      expect(accountsServerMock.impersonate).toHaveBeenCalledWith(accessToken, { username }, infos);
     });
   });
 
@@ -96,14 +92,15 @@ describe('accounts resolvers mutation', () => {
       await Mutation.refreshTokens!(
         {},
         { accessToken, refreshToken },
-        { injector, ip, userAgent } as any,
+        { injector, infos } as any,
         {} as any
       );
       expect(injector.get).toHaveBeenCalledWith(AccountsServer);
-      expect(accountsServerMock.refreshTokens).toHaveBeenCalledWith(accessToken, refreshToken, {
-        ip,
-        userAgent,
-      });
+      expect(accountsServerMock.refreshTokens).toHaveBeenCalledWith(
+        accessToken,
+        refreshToken,
+        infos
+      );
     });
   });
 });

--- a/packages/graphql-api/src/modules/accounts-password/resolvers/mutation.ts
+++ b/packages/graphql-api/src/modules/accounts-password/resolvers/mutation.ts
@@ -25,7 +25,7 @@ export const Mutation: MutationResolvers<ModuleContext<AccountsModuleContext>> =
     return null;
   },
   createUser: async (_, { user }, ctx) => {
-    const { ip, userAgent, injector } = ctx;
+    const { injector, infos } = ctx;
     const accountsServer = injector.get(AccountsServer);
     const accountsPassword = injector.get(AccountsPassword);
 
@@ -60,10 +60,7 @@ export const Mutation: MutationResolvers<ModuleContext<AccountsModuleContext>> =
 
     // If we are here - user must be created successfully
     // Explicitly saying this to Typescript compiler
-    const loginResult = await accountsServer.loginWithUser(createdUser!, {
-      ip,
-      userAgent,
-    });
+    const loginResult = await accountsServer.loginWithUser(createdUser!, infos);
 
     return {
       userId,
@@ -92,8 +89,8 @@ export const Mutation: MutationResolvers<ModuleContext<AccountsModuleContext>> =
     await injector.get(AccountsPassword).twoFactor.unset(userId, code);
     return null;
   },
-  resetPassword: async (_, { token, newPassword }, { injector, ip, userAgent }) => {
-    return injector.get(AccountsPassword).resetPassword(token, newPassword, { ip, userAgent });
+  resetPassword: async (_, { token, newPassword }, { injector, infos }) => {
+    return injector.get(AccountsPassword).resetPassword(token, newPassword, infos);
   },
   sendResetPasswordEmail: async (_, { email }, { injector }) => {
     await injector.get(AccountsPassword).sendResetPasswordEmail(email);

--- a/packages/graphql-api/src/modules/accounts/index.ts
+++ b/packages/graphql-api/src/modules/accounts/index.ts
@@ -1,5 +1,8 @@
 import { GraphQLModule } from '@graphql-modules/core';
+import { mergeTypeDefs } from '@graphql-toolkit/schema-merging';
+import { User, ConnectionInformations } from '@accounts/types';
 import { AccountsServer } from '@accounts/server';
+import AccountsPassword from '@accounts/password';
 import { IncomingMessage } from 'http';
 import TypesTypeDefs from './schema/types';
 import getQueryTypeDefs from './schema/query';
@@ -8,12 +11,9 @@ import getSchemaDef from './schema/schema-def';
 import { Query } from './resolvers/query';
 import { Mutation } from './resolvers/mutation';
 import { User as UserResolvers } from './resolvers/user';
-import { User } from '@accounts/types';
 import { AccountsPasswordModule } from '../accounts-password';
 import { AuthenticatedDirective } from '../../utils/authenticated-directive';
 import { context } from '../../utils';
-import AccountsPassword from '@accounts/password';
-import { mergeTypeDefs } from '@graphql-toolkit/schema-merging';
 import { CoreAccountsModule } from '../core';
 
 export interface AccountsRequest {
@@ -33,10 +33,11 @@ export interface AccountsModuleConfig {
 
 export interface AccountsModuleContext<IUser = User> {
   authToken?: string;
-  userAgent: string | null;
-  ip: string | null;
   user?: IUser;
   userId?: string;
+  userAgent: string | null;
+  ip: string | null;
+  infos: ConnectionInformations;
 }
 
 // You can see the below. It is really easy to create a reusable GraphQL-Module with different configurations

--- a/packages/graphql-api/src/modules/accounts/resolvers/mutation.ts
+++ b/packages/graphql-api/src/modules/accounts/resolvers/mutation.ts
@@ -6,33 +6,29 @@ import { AccountsServer } from '@accounts/server';
 export const Mutation: MutationResolvers<ModuleContext<AccountsModuleContext>> = {
   authenticate: async (_, args, ctx) => {
     const { serviceName, params } = args;
-    const { ip, userAgent, injector } = ctx;
+    const { injector, infos } = ctx;
 
-    const authenticated = await injector.get(AccountsServer).loginWithService(serviceName, params, {
-      ip,
-      userAgent,
-    });
+    const authenticated = await injector
+      .get(AccountsServer)
+      .loginWithService(serviceName, params, infos);
     return authenticated;
   },
   verifyAuthentication: async (_, args, ctx) => {
     const { serviceName, params } = args;
-    const { ip, userAgent, injector } = ctx;
+    const { injector, infos } = ctx;
 
     const authenticated = await injector
       .get(AccountsServer)
-      .authenticateWithService(serviceName, params, {
-        ip,
-        userAgent,
-      });
+      .authenticateWithService(serviceName, params, infos);
     return authenticated;
   },
   impersonate: async (_, args, ctx) => {
     const { accessToken, username } = args;
-    const { ip, userAgent, injector } = ctx;
+    const { injector, infos } = ctx;
 
     const impersonateRes = await injector
       .get(AccountsServer)
-      .impersonate(accessToken, { username }, { ip, userAgent });
+      .impersonate(accessToken, { username }, infos);
 
     // So ctx.user can be used in subsequent queries / mutations
     if (impersonateRes && impersonateRes.user && impersonateRes.tokens) {
@@ -53,11 +49,11 @@ export const Mutation: MutationResolvers<ModuleContext<AccountsModuleContext>> =
   },
   refreshTokens: async (_, args, ctx) => {
     const { accessToken, refreshToken } = args;
-    const { ip, userAgent, injector } = ctx;
+    const { injector, infos } = ctx;
 
     const refreshedSession = await injector
       .get(AccountsServer)
-      .refreshTokens(accessToken, refreshToken, { ip, userAgent });
+      .refreshTokens(accessToken, refreshToken, infos);
 
     return refreshedSession;
   },

--- a/packages/graphql-api/src/utils/context-builder.ts
+++ b/packages/graphql-api/src/utils/context-builder.ts
@@ -1,6 +1,6 @@
-import { AccountsRequest, AccountsModuleConfig } from '../modules';
 import { ModuleConfig, ModuleSessionInfo } from '@graphql-modules/core';
 import { getClientIp } from 'request-ip';
+import { AccountsRequest, AccountsModuleConfig } from '../modules';
 
 export const context = (moduleName: string) => async (
   { req }: AccountsRequest,
@@ -11,6 +11,10 @@ export const context = (moduleName: string) => async (
     return {
       ip: '',
       userAgent: '',
+      infos: {
+        ip: '',
+        userAgent: '',
+      },
     };
   }
 
@@ -28,6 +32,7 @@ export const context = (moduleName: string) => async (
     }
   }
 
+  const ip = getClientIp(req);
   let userAgent: string = (req.headers['user-agent'] as string) || '';
   if (req.headers['x-ucbrowser-ua']) {
     // special case of UC Browser
@@ -36,9 +41,13 @@ export const context = (moduleName: string) => async (
 
   return {
     authToken,
-    userAgent,
-    ip: getClientIp(req),
     user,
     userId: user && user.id,
+    userAgent,
+    ip,
+    infos: {
+      userAgent,
+      ip,
+    },
   };
 };

--- a/packages/types/src/types/connection-informations.ts
+++ b/packages/types/src/types/connection-informations.ts
@@ -1,4 +1,5 @@
 export interface ConnectionInformations {
   ip?: string | null;
   userAgent?: string | null;
+  [key: string]: any;
 }


### PR DESCRIPTION
The goal of this pr is to provide a way for the user to extends the info object that will be passed down to the server functions from the GraphQL context.
I will create another pr adding this for REST too.