### PR TITLE
fix!: fix impersonate transports params

### DIFF
--- a/packages/client/src/transport-interface.ts
+++ b/packages/client/src/transport-interface.ts
@@ -1,5 +1,6 @@
 import {
   LoginResult,
+  ImpersonationUserIdentity,
   ImpersonationResult,
   CreateUser,
   User,
@@ -31,12 +32,5 @@ export interface TransportInterface {
   resetPassword(token: string, newPassword: string): Promise<LoginResult | null>;
   addEmail(newEmail: string): Promise<void>;
   changePassword(oldPassword: string, newPassword: string): Promise<void>;
-  impersonate(
-    token: string,
-    impersonated: {
-      userId?: string;
-      username?: string;
-      email?: string;
-    }
-  ): Promise<ImpersonationResult>;
+  impersonate(token: string, impersonated: ImpersonationUserIdentity): Promise<ImpersonationResult>;
 }

--- a/packages/graphql-api/__tests__/modules/accounts/resolvers/mutation.ts
+++ b/packages/graphql-api/__tests__/modules/accounts/resolvers/mutation.ts
@@ -61,12 +61,16 @@ describe('accounts resolvers mutation', () => {
     it('should call impersonate', async () => {
       await Mutation.impersonate!(
         {},
-        { accessToken, username } as any,
+        { accessToken, impersonated: { username } } as any,
         { injector, infos } as any,
         {} as any
       );
       expect(injector.get).toHaveBeenCalledWith(AccountsServer);
-      expect(accountsServerMock.impersonate).toHaveBeenCalledWith(accessToken, { username }, infos);
+      expect(accountsServerMock.impersonate).toHaveBeenCalledWith(
+        accessToken,
+        { userId: undefined, username, email: undefined },
+        infos
+      );
     });
   });
 

--- a/packages/graphql-api/src/models.ts
+++ b/packages/graphql-api/src/models.ts
@@ -47,6 +47,12 @@ export type ImpersonateReturn = {
   user?: Maybe<User>;
 };
 
+export type ImpersonationUserIdentityInput = {
+  userId?: Maybe<Scalars['String']>;
+  username?: Maybe<Scalars['String']>;
+  email?: Maybe<Scalars['String']>;
+};
+
 export type LoginResult = {
    __typename?: 'LoginResult';
   sessionId?: Maybe<Scalars['String']>;
@@ -123,7 +129,7 @@ export type MutationTwoFactorUnsetArgs = {
 
 export type MutationImpersonateArgs = {
   accessToken: Scalars['String'];
-  username: Scalars['String'];
+  impersonated: ImpersonationUserIdentityInput;
 };
 
 
@@ -270,6 +276,7 @@ export type ResolversTypes = {
   LoginResult: ResolverTypeWrapper<LoginResult>,
   Tokens: ResolverTypeWrapper<Tokens>,
   TwoFactorSecretKeyInput: TwoFactorSecretKeyInput,
+  ImpersonationUserIdentityInput: ImpersonationUserIdentityInput,
   ImpersonateReturn: ResolverTypeWrapper<ImpersonateReturn>,
   AuthenticateParamsInput: AuthenticateParamsInput,
   UserInput: UserInput,
@@ -290,6 +297,7 @@ export type ResolversParentTypes = {
   LoginResult: LoginResult,
   Tokens: Tokens,
   TwoFactorSecretKeyInput: TwoFactorSecretKeyInput,
+  ImpersonationUserIdentityInput: ImpersonationUserIdentityInput,
   ImpersonateReturn: ImpersonateReturn,
   AuthenticateParamsInput: AuthenticateParamsInput,
   UserInput: UserInput,
@@ -335,7 +343,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   changePassword?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<MutationChangePasswordArgs, 'oldPassword' | 'newPassword'>>,
   twoFactorSet?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<MutationTwoFactorSetArgs, 'secret' | 'code'>>,
   twoFactorUnset?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<MutationTwoFactorUnsetArgs, 'code'>>,
-  impersonate?: Resolver<Maybe<ResolversTypes['ImpersonateReturn']>, ParentType, ContextType, RequireFields<MutationImpersonateArgs, 'accessToken' | 'username'>>,
+  impersonate?: Resolver<Maybe<ResolversTypes['ImpersonateReturn']>, ParentType, ContextType, RequireFields<MutationImpersonateArgs, 'accessToken' | 'impersonated'>>,
   refreshTokens?: Resolver<Maybe<ResolversTypes['LoginResult']>, ParentType, ContextType, RequireFields<MutationRefreshTokensArgs, 'accessToken' | 'refreshToken'>>,
   logout?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>,
   authenticate?: Resolver<Maybe<ResolversTypes['LoginResult']>, ParentType, ContextType, RequireFields<MutationAuthenticateArgs, 'serviceName' | 'params'>>,

--- a/packages/graphql-api/src/modules/accounts/resolvers/mutation.ts
+++ b/packages/graphql-api/src/modules/accounts/resolvers/mutation.ts
@@ -1,7 +1,7 @@
-import { MutationResolvers } from '../../../models';
 import { ModuleContext } from '@graphql-modules/core';
-import { AccountsModuleContext } from '..';
 import { AccountsServer } from '@accounts/server';
+import { MutationResolvers } from '../../../models';
+import { AccountsModuleContext } from '..';
 
 export const Mutation: MutationResolvers<ModuleContext<AccountsModuleContext>> = {
   authenticate: async (_, args, ctx) => {
@@ -23,12 +23,18 @@ export const Mutation: MutationResolvers<ModuleContext<AccountsModuleContext>> =
     return authenticated;
   },
   impersonate: async (_, args, ctx) => {
-    const { accessToken, username } = args;
+    const { accessToken, impersonated } = args;
     const { injector, infos } = ctx;
 
-    const impersonateRes = await injector
-      .get(AccountsServer)
-      .impersonate(accessToken, { username }, infos);
+    const impersonateRes = await injector.get(AccountsServer).impersonate(
+      accessToken,
+      {
+        userId: impersonated.userId!,
+        username: impersonated.username!,
+        email: impersonated.email!,
+      },
+      infos
+    );
 
     // So ctx.user can be used in subsequent queries / mutations
     if (impersonateRes && impersonateRes.user && impersonateRes.tokens) {

--- a/packages/graphql-api/src/modules/accounts/schema/mutation.ts
+++ b/packages/graphql-api/src/modules/accounts/schema/mutation.ts
@@ -3,7 +3,7 @@ import { AccountsModuleConfig } from '..';
 
 export default (config: AccountsModuleConfig) => gql`
   ${config.extendTypeDefs ? 'extend' : ''} type ${config.rootMutationName || 'Mutation'} {
-    impersonate(accessToken: String!, username: String!): ImpersonateReturn
+    impersonate(accessToken: String!, impersonated: ImpersonationUserIdentityInput!): ImpersonateReturn
     refreshTokens(accessToken: String!, refreshToken: String!): LoginResult
     logout: Boolean
 

--- a/packages/graphql-api/src/modules/accounts/schema/types.ts
+++ b/packages/graphql-api/src/modules/accounts/schema/types.ts
@@ -29,4 +29,10 @@ export default gql`
     # Two factor
     code: String
   }
+
+  input ImpersonationUserIdentityInput {
+    userId: String
+    username: String
+    email: String
+  }
 `;

--- a/packages/rest-client/__tests__/rest-client.ts
+++ b/packages/rest-client/__tests__/rest-client.ts
@@ -106,7 +106,7 @@ describe('RestClient', () => {
   describe('impersonate', () => {
     it('should call fetch with impersonate path', () =>
       restClient
-        .impersonate('token', { id: 'user' })
+        .impersonate('token', { userId: 'user' })
         .then(() =>
           expect((window.fetch as jest.Mock).mock.calls[0][0]).toBe(
             'http://localhost:3000/accounts/impersonate'

--- a/packages/rest-client/src/rest-client.ts
+++ b/packages/rest-client/src/rest-client.ts
@@ -4,8 +4,8 @@ import {
   User,
   LoginResult,
   CreateUser,
+  ImpersonationUserIdentity,
   ImpersonationResult,
-  LoginUserIdentity,
   CreateUserResult,
 } from '@accounts/types';
 import { AccountsJsError } from './accounts-error';
@@ -91,7 +91,7 @@ export class RestClient implements TransportInterface {
 
   public impersonate(
     accessToken: string,
-    impersonated: LoginUserIdentity,
+    impersonated: ImpersonationUserIdentity,
     customHeaders?: object
   ): Promise<ImpersonationResult> {
     const args = {

--- a/packages/rest-express/src/endpoints/impersonate.ts
+++ b/packages/rest-express/src/endpoints/impersonate.ts
@@ -1,7 +1,7 @@
 import * as express from 'express';
 import * as requestIp from 'request-ip';
 import { AccountsServer } from '@accounts/server';
-import { LoginUserIdentity } from '@accounts/types';
+import { ImpersonationUserIdentity } from '@accounts/types';
 import { getUserAgent } from '../utils/get-user-agent';
 import { sendError } from '../utils/send-error';
 
@@ -15,7 +15,7 @@ export const impersonate = (accountsServer: AccountsServer) => async (
       accessToken,
     }: {
       accessToken: string;
-      impersonated: LoginUserIdentity;
+      impersonated: ImpersonationUserIdentity;
     } = req.body;
     const userAgent = getUserAgent(req);
     const ip = requestIp.getClientIp(req);

--- a/packages/server/src/accounts-server.ts
+++ b/packages/server/src/accounts-server.ts
@@ -6,6 +6,7 @@ import {
   LoginResult,
   Tokens,
   Session,
+  ImpersonationUserIdentity,
   ImpersonationResult,
   HookListener,
   DatabaseInterface,
@@ -256,11 +257,7 @@ Please set ambiguousErrorMessages to false to be able to use autologin.`
    */
   public async impersonate(
     accessToken: string,
-    impersonated: {
-      userId?: string;
-      username?: string;
-      email?: string;
-    },
+    impersonated: ImpersonationUserIdentity,
     infos: ConnectionInformations
   ): Promise<ImpersonationResult> {
     try {

--- a/packages/types/src/types/impersonation-result.ts
+++ b/packages/types/src/types/impersonation-result.ts
@@ -1,6 +1,12 @@
 import { Tokens } from './tokens';
 import { User } from './user';
 
+export interface ImpersonationUserIdentity {
+  userId?: string;
+  username?: string;
+  email?: string;
+}
+
 export interface ImpersonationResult {
   authorized: boolean;
   tokens?: Tokens;


### PR DESCRIPTION
Close #827

## Breaking changes

- `graphql-api`: changed the types of the `impersonate` mutation to allow to impersonation via `userId` and `email`