### PR TITLE
fix(typeorm): add explicit types to userSession and IP decorator

### DIFF
--- a/packages/database-typeorm/src/entity/UserSession.ts
+++ b/packages/database-typeorm/src/entity/UserSession.ts
@@ -22,10 +22,10 @@ export class UserSession {
   @Column()
   public valid!: boolean;
 
-  @Column({ nullable: true })
+  @Column({ type: 'text', nullable: true })
   public userAgent?: string | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'text', nullable: true })
   public ip?: string | null;
 
   @Column('jsonb', { nullable: true })


### PR DESCRIPTION
This attempts to address the following issue when running the example repo for postgres + GraphQL (Close https://github.com/accounts-js/accounts/issues/991).

TypeORM has difficulty inferring underlying types from nullable types and will cast something like `string | null` into `object`. This PR adds an explicit type to typeORM's decorator.