### PR TITLE
docs: fix missing await in getting started

### DIFF
--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -47,7 +47,8 @@ import accountsBoost from `@accounts/boost`;
 
   const accounts = await accountsBoost({
     tokenSecret: 'your secret'
-  }).listen({
+  });
+  const accountsServer = await accounts.listen({
     port: 4003
   });
 


### PR DESCRIPTION
You where calling `.listen` on the promise.

other option would've been `await (await accountsBoost(...)).listen`,
but I figured that could be a bit confusing.