### PR TITLE
feat(graphql-api): custom typings for authenticated-resolver

### DIFF
--- a/packages/graphql-api/src/utils/authenticated-resolver.ts
+++ b/packages/graphql-api/src/utils/authenticated-resolver.ts
@@ -1,8 +1,8 @@
-export const authenticated = (func: any) => async (
-  root: any,
-  args: any,
-  context: any,
-  info: any
+export const authenticated = <R, A, C, I, T>(func: (root: R, args: A, context: C, info: I) => T | Promise<T>) => async (
+  root: R,
+  args: A,
+  context: C,
+  info: I
 ) => {
   if (context && context.skipJSAccountsVerification === true) {
     return func(root, args, context, info);

--- a/packages/graphql-api/src/utils/authenticated-resolver.ts
+++ b/packages/graphql-api/src/utils/authenticated-resolver.ts
@@ -1,9 +1,6 @@
-export const authenticated = <R, A, C, I, T>(func: (root: R, args: A, context: C, info: I) => T | Promise<T>) => async (
-  root: R,
-  args: A,
-  context: C,
-  info: I
-) => {
+export const authenticated = <CustomRoot, CustomArgs, Context, Info, T>(
+  func: (root: CustomRoot, args: CustomArgs, context: Context, info: Info) => T | Promise<T>
+) => async (root: CustomRoot, args: CustomArgs, context: Context, info: Info) => {
   if (context && context.skipJSAccountsVerification === true) {
     return func(root, args, context, info);
   }

--- a/packages/graphql-api/src/utils/authenticated-resolver.ts
+++ b/packages/graphql-api/src/utils/authenticated-resolver.ts
@@ -1,6 +1,17 @@
-export const authenticated = <CustomRoot, CustomArgs, Context, Info, T>(
-  func: (root: CustomRoot, args: CustomArgs, context: Context, info: Info) => T | Promise<T>
-) => async (root: CustomRoot, args: CustomArgs, context: Context, info: Info) => {
+export const authenticated = <
+  CustomRoot,
+  CustomArgs,
+  CustomContext extends { skipJSAccountsVerification?: Boolean; userId?: any; user?: any },
+  Info,
+  ReturnType
+>(
+  func: (
+    root: CustomRoot,
+    args: CustomArgs,
+    context: CustomContext,
+    info: Info
+  ) => ReturnType | Promise<ReturnType>
+) => async (root: CustomRoot, args: CustomArgs, context: CustomContext, info: Info) => {
   if (context && context.skipJSAccountsVerification === true) {
     return func(root, args, context, info);
   }


### PR DESCRIPTION
I'm using it with nexus.js.org and it would break the types because it says 'any' for all of them.