### PR TITLE
docs: use gender neutral language in documentation

### DIFF
--- a/website/docs/server.md
+++ b/website/docs/server.md
@@ -43,7 +43,7 @@ The `@accounts/server` module exposes a set of methods that can be used directly
 
 ### Find a user
 
-Find a user by his id.
+Find a user by their id.
 
 ```javascript
 const user = await accountsServer.findUserById(userId);
@@ -101,7 +101,7 @@ const loginResult = await accountsServer.loginWithUser(user, {
 
 ### Deactivate a user
 
-Deactivate a user, the user will not be able to login until his account is reactivated.
+Deactivate a user, the user will not be able to login until their account is reactivated.
 
 ```javascript
 await accountsServer.deactivateUser(userId);
@@ -117,7 +117,7 @@ await accountsServer.activateUser(userId);
 
 ### Logout a user
 
-Logout a user and invalidate his session with the session access token.
+Logout a user and invalidate their session with the session access token.
 
 ```javascript
 await accountsServer.logout(accessToken);

--- a/website/docs/strategies/password-client.md
+++ b/website/docs/strategies/password-client.md
@@ -66,7 +66,7 @@ await accountsPassword.resetPassword('token', 'newPassword');
 
 ### Verify email
 
-When a user is created, his email will be marked as unverified. To verify the user email, the first step is to send him an email containing a random secret. Then your application needs to send this token to the server to verify the email of the user.
+When a user is created, their email will be marked as unverified. To verify the user email, the first step is to send him an email containing a random secret. Then your application needs to send this token to the server to verify the email of the user.
 
 ```javascript
 // Send an email with a link the user can use verify their email address.


### PR DESCRIPTION
the users your documentation refers to are not all people that would be referred to as 'him'. using gender neutral language is welcoming to more potential users of AccountsJS