### PR TITLE
chore: only publish build and source to npm

### DIFF
--- a/packages/apollo-link-accounts/.npmignore
+++ b/packages/apollo-link-accounts/.npmignore
@@ -1,7 +1,0 @@
-__tests__
-src/
-coverage/
-node_modules
-tsconfig.json
-.npmignore
-yarn.lock

--- a/packages/apollo-link-accounts/package.json
+++ b/packages/apollo-link-accounts/package.json
@@ -14,6 +14,10 @@
     "compile": "tsc",
     "prepublishOnly": "yarn compile"
   },
+  "files": [
+    "src",
+    "lib"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/accounts-js/accounts/tree/master/packages/apollo-link"

--- a/packages/boost/.npmignore
+++ b/packages/boost/.npmignore
@@ -1,7 +1,0 @@
-__tests__
-src/
-coverage/
-node_modules
-tsconfig.json
-.npmignore
-yarn.lock

--- a/packages/boost/package.json
+++ b/packages/boost/package.json
@@ -14,6 +14,10 @@
     "compile": "tsc",
     "prepublishOnly": "yarn compile"
   },
+  "files": [
+    "src",
+    "lib"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/accounts-js/accounts/tree/master/packages/boost"

--- a/packages/client-password/.npmignore
+++ b/packages/client-password/.npmignore
@@ -1,7 +1,0 @@
-__tests__
-src/
-coverage/
-node_modules
-tsconfig.json
-.npmignore
-yarn.lock

--- a/packages/client-password/package.json
+++ b/packages/client-password/package.json
@@ -19,6 +19,10 @@
     "test:watch": "jest --watch",
     "coverage": "yarn testonly --coverage"
   },
+  "files": [
+    "src",
+    "lib"
+  ],
   "jest": {
     "preset": "ts-jest"
   },

--- a/packages/client/.npmignore
+++ b/packages/client/.npmignore
@@ -1,7 +1,0 @@
-__tests__
-src/
-coverage/
-node_modules
-tsconfig.json
-.npmignore
-yarn.lock

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -19,6 +19,10 @@
     "test:watch": "jest --watch",
     "coverage": "npm run testonly -- --coverage"
   },
+  "files": [
+    "src",
+    "lib"
+  ],
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "jsdom",

--- a/packages/database-manager/package.json
+++ b/packages/database-manager/package.json
@@ -17,6 +17,10 @@
     "testonly": "jest --coverage",
     "coverage": "jest --coverage"
   },
+  "files": [
+    "src",
+    "lib"
+  ],
   "jest": {
     "testEnvironment": "node",
     "preset": "ts-jest"

--- a/packages/database-tests/package.json
+++ b/packages/database-tests/package.json
@@ -11,6 +11,10 @@
     "compile": "tsc",
     "prepublishOnly": "yarn compile"
   },
+  "files": [
+    "src",
+    "lib"
+  ],
   "jest": {
     "testEnvironment": "node",
     "preset": "ts-jest"

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -7,6 +7,10 @@
   "scripts": {
     "coverage": "jest --forceExit --runInBand"
   },
+  "files": [
+    "src",
+    "lib"
+  ],
   "jest": {
     "testEnvironment": "node",
     "setupFiles": [

--- a/packages/error/.npmignore
+++ b/packages/error/.npmignore
@@ -1,7 +1,0 @@
-__tests__
-src/
-coverage/
-node_modules
-tsconfig.json
-.npmignore
-yarn.lock

--- a/packages/error/package.json
+++ b/packages/error/package.json
@@ -19,6 +19,10 @@
     "test:watch": "yarn testonly --watch",
     "coverage": "yarn testonly --coverage"
   },
+  "files": [
+    "src",
+    "lib"
+  ],
   "jest": {
     "testEnvironment": "node",
     "preset": "ts-jest"

--- a/packages/express-session/.npmignore
+++ b/packages/express-session/.npmignore
@@ -1,7 +1,0 @@
-__tests__
-src/
-coverage/
-node_modules
-.npmignore
-tsconfig.json
-yarn.lock

--- a/packages/express-session/package.json
+++ b/packages/express-session/package.json
@@ -17,6 +17,10 @@
     "test:watch": "jest --watch",
     "coverage": "jest --coverage"
   },
+  "files": [
+    "src",
+    "lib"
+  ],
   "jest": {
     "testEnvironment": "node",
     "preset": "ts-jest"

--- a/packages/graphql-api/.npmignore
+++ b/packages/graphql-api/.npmignore
@@ -1,6 +1,0 @@
-src/
-coverage/
-node_modules
-yarn.lock
-tsconfig.json
-.npmignore

--- a/packages/graphql-api/package.json
+++ b/packages/graphql-api/package.json
@@ -13,6 +13,10 @@
     "coverage": "yarn testonly --coverage",
     "prepublishOnly": "yarn compile"
   },
+  "files": [
+    "src",
+    "lib"
+  ],
   "jest": {
     "testEnvironment": "node",
     "preset": "ts-jest"

--- a/packages/graphql-client/.npmignore
+++ b/packages/graphql-client/.npmignore
@@ -1,6 +1,0 @@
-src/
-coverage/
-node_modules
-yarn.lock
-tsconfig.json
-.npmignore

--- a/packages/graphql-client/package.json
+++ b/packages/graphql-client/package.json
@@ -11,6 +11,10 @@
     "compile": "tsc",
     "prepublishOnly": "yarn compile"
   },
+  "files": [
+    "src",
+    "lib"
+  ],
   "jest": {
     "preset": "ts-jest"
   },

--- a/packages/oauth-instagram/package.json
+++ b/packages/oauth-instagram/package.json
@@ -13,6 +13,10 @@
     "testonly": "jest",
     "coverage": "jest --coverage"
   },
+  "files": [
+    "src",
+    "lib"
+  ],
   "jest": {
     "testEnvironment": "node",
     "preset": "ts-jest"

--- a/packages/oauth-twitter/package.json
+++ b/packages/oauth-twitter/package.json
@@ -13,6 +13,10 @@
     "testonly": "jest",
     "coverage": "jest --coverage"
   },
+  "files": [
+    "src",
+    "lib"
+  ],
   "jest": {
     "testEnvironment": "node",
     "preset": "ts-jest"

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -13,6 +13,10 @@
     "test:watch": "jest --watch",
     "coverage": "jest --coverage"
   },
+  "files": [
+    "src",
+    "lib"
+  ],
   "jest": {
     "testEnvironment": "node",
     "preset": "ts-jest"

--- a/packages/password/package.json
+++ b/packages/password/package.json
@@ -13,6 +13,10 @@
     "testonly": "jest --coverage",
     "coverage": "jest --coverage"
   },
+  "files": [
+    "src",
+    "lib"
+  ],
   "jest": {
     "testEnvironment": "node",
     "preset": "ts-jest"

--- a/packages/rest-client/.npmignore
+++ b/packages/rest-client/.npmignore
@@ -1,7 +1,0 @@
-__tests__
-src/
-coverage/
-node_modules
-.npmignore
-tsconfig.json
-yarn.lock

--- a/packages/rest-client/package.json
+++ b/packages/rest-client/package.json
@@ -17,6 +17,10 @@
     "testonly": "jest",
     "coverage": "npm run testonly -- --coverage"
   },
+  "files": [
+    "src",
+    "lib"
+  ],
   "jest": {
     "testEnvironment": "jsdom",
     "preset": "ts-jest"

--- a/packages/rest-express/.npmignore
+++ b/packages/rest-express/.npmignore
@@ -1,7 +1,0 @@
-__tests__
-src/
-coverage/
-node_modules
-.npmignore
-tsconfig.json
-yarn.lock

--- a/packages/rest-express/package.json
+++ b/packages/rest-express/package.json
@@ -18,6 +18,10 @@
     "testonly": "jest",
     "coverage": "npm run testonly -- --coverage"
   },
+  "files": [
+    "src",
+    "lib"
+  ],
   "jest": {
     "testEnvironment": "node",
     "preset": "ts-jest"

--- a/packages/server/.npmignore
+++ b/packages/server/.npmignore
@@ -1,7 +1,0 @@
-__tests__
-src/
-coverage/
-node_modules
-tsconfig.json
-.npmignore
-yarn.lock

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,6 +19,10 @@
     "test:watch": "jest --watch",
     "coverage": "npm run testonly -- --coverage"
   },
+  "files": [
+    "src",
+    "lib"
+  ],
   "jest": {
     "testEnvironment": "node",
     "preset": "ts-jest"

--- a/packages/two-factor/package.json
+++ b/packages/two-factor/package.json
@@ -17,6 +17,10 @@
     "testonly": "jest --coverage",
     "coverage": "jest --coverage"
   },
+  "files": [
+    "src",
+    "lib"
+  ],
   "jest": {
     "testEnvironment": "node",
     "preset": "ts-jest"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -19,6 +19,10 @@
     "test:watch": "yarn testonly --watch",
     "coverage": "yarn testonly --coverage"
   },
+  "files": [
+    "src",
+    "lib"
+  ],
   "jest": {
     "testEnvironment": "node",
     "preset": "ts-jest"


### PR DESCRIPTION
Will limit the number of files published to npm (eg: no tests, no coverage artifacts)
- delete existing npmignore files
- aff "files" config to package.json