### PR TITLE
feat(accounts-client): Add option to customize token sepearator character

### DIFF
--- a/packages/client/src/accounts-client.ts
+++ b/packages/client/src/accounts-client.ts
@@ -103,7 +103,7 @@ export class AccountsClient {
    * Refresh the user session
    * If the tokens have expired try to refresh them
    */
-  public async refreshSession(force: boolean = false): Promise<Tokens | null> {
+  public async refreshSession(force = false): Promise<Tokens | null> {
     const tokens = await this.getTokens();
     if (tokens) {
       try {

--- a/packages/client/src/types/options.ts
+++ b/packages/client/src/types/options.ts
@@ -11,4 +11,9 @@ export interface AccountsClientOptions {
    * Default: 'accounts'.
    */
   tokenStoragePrefix?: string;
+  /**
+   * String or character that will separate the storage key name from it's value.
+   * Default: ':'.
+   */
+  tokenStorageSeparator?: string;
 }


### PR DESCRIPTION
When using cookies ':' renders as '%3A' as cookies only can handle some characters/encoding.

This lets me change the separator