### PR TITLE
chore(password)!: move `sendResetPasswordEmail` user check to transport

### DIFF
--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -521,10 +521,6 @@ export default class AccountsPassword<CustomUser extends User = User>
 
     const user = await this.db.findUserByEmail(address);
     if (!user) {
-      // To prevent user enumeration we fail silently
-      if (this.server.options.ambiguousErrorMessages) {
-        return;
-      }
       throw new AccountsJsError(
         this.options.errors.userNotFound,
         SendResetPasswordEmailErrors.UserNotFound

--- a/packages/rest-express/src/endpoints/password/reset.ts
+++ b/packages/rest-express/src/endpoints/password/reset.ts
@@ -1,6 +1,6 @@
 import * as express from 'express';
-import { AccountsServer } from '@accounts/server';
-import { AccountsPassword } from '@accounts/password';
+import { AccountsJsError, AccountsServer } from '@accounts/server';
+import { AccountsPassword, SendResetPasswordEmailErrors } from '@accounts/password';
 import { sendError } from '../../utils/send-error';
 
 export const resetPassword = (accountsServer: AccountsServer) => async (
@@ -24,7 +24,21 @@ export const sendResetPasswordEmail = (accountsServer: AccountsServer) => async 
   try {
     const { email } = req.body;
     const accountsPassword = accountsServer.getServices().password as AccountsPassword;
-    await accountsPassword.sendResetPasswordEmail(email);
+
+    try {
+      await accountsPassword.sendResetPasswordEmail(email);
+    } catch (error) {
+      // If ambiguousErrorMessages is true,
+      // to prevent user enumeration we fail silently in case there is no user attached to this email
+      if (
+        accountsServer.options.ambiguousErrorMessages &&
+        error instanceof AccountsJsError &&
+        error.code === SendResetPasswordEmailErrors.UserNotFound
+      ) {
+        return res.json(null);
+      }
+      throw error;
+    }
     res.json(null);
   } catch (err) {
     sendError(res, err);


### PR DESCRIPTION
BREAKING CHANGE: calling `password.sendResetPasswordEmail` will not hide the error anymore if the user is not found when `ambiguousErrorMessages` is true, this error will now be hidden by the transport layer (rest-express, graphql).
**Only a breaking change if** you expose `password.sendResetPasswordEmail` to your users without using the one of the transport layers.

This change is made to make the service a bit more "dumb" and to allow to call this function server side and get the error in case the user is not found.