### PR TITLE
chore(password)!: move `sendVerificationEmail` user check to transport 

### DIFF
--- a/packages/graphql-api/package.json
+++ b/packages/graphql-api/package.json
@@ -61,7 +61,8 @@
     "@types/request-ip": "0.0.35",
     "concurrently": "5.2.0",
     "graphql": "14.6.0",
-    "jest": "26.0.1",
+    "jest": "26.6.3",
+    "ts-jest": "26.4.4",
     "ts-node": "8.10.1"
   }
 }

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -469,10 +469,6 @@ export default class AccountsPassword<CustomUser extends User = User>
 
     const user = await this.db.findUserByEmail(address);
     if (!user) {
-      // To prevent user enumeration we fail silently
-      if (this.server.options.ambiguousErrorMessages) {
-        return;
-      }
       throw new AccountsJsError(
         this.options.errors.userNotFound,
         SendVerificationEmailErrors.UserNotFound

--- a/packages/rest-express/package.json
+++ b/packages/rest-express/package.json
@@ -55,6 +55,6 @@
     "@types/node": "14.0.14",
     "@types/request-ip": "0.0.35",
     "jest": "26.6.3",
-    "ts-jest": "26.4.0"
+    "ts-jest": "26.4.4"
   }
 }

--- a/packages/rest-express/package.json
+++ b/packages/rest-express/package.json
@@ -38,15 +38,6 @@
   ],
   "author": "Tim Mikeladze",
   "license": "MIT",
-  "devDependencies": {
-    "@accounts/password": "^0.29.0",
-    "@accounts/server": "^0.29.0",
-    "@types/express": "4.17.6",
-    "@types/jest": "25.2.3",
-    "@types/node": "14.0.14",
-    "@types/request-ip": "0.0.35",
-    "jest": "26.0.1"
-  },
   "peerDependencies": {
     "@accounts/server": "^0.19.0"
   },
@@ -55,5 +46,15 @@
     "express": "^4.17.0",
     "request-ip": "^2.1.3",
     "tslib": "2.0.0"
+  },
+  "devDependencies": {
+    "@accounts/password": "^0.29.0",
+    "@accounts/server": "^0.29.0",
+    "@types/express": "4.17.6",
+    "@types/jest": "25.2.3",
+    "@types/node": "14.0.14",
+    "@types/request-ip": "0.0.35",
+    "jest": "26.6.3",
+    "ts-jest": "26.4.0"
   }
 }

--- a/packages/rest-express/src/endpoints/password/verify-email.ts
+++ b/packages/rest-express/src/endpoints/password/verify-email.ts
@@ -1,6 +1,6 @@
 import * as express from 'express';
-import { AccountsServer } from '@accounts/server';
-import { AccountsPassword } from '@accounts/password';
+import { AccountsJsError, AccountsServer } from '@accounts/server';
+import { AccountsPassword, SendVerificationEmailErrors } from '@accounts/password';
 import { sendError } from '../../utils/send-error';
 
 export const verifyEmail = (accountsServer: AccountsServer) => async (
@@ -24,7 +24,20 @@ export const sendVerificationEmail = (accountsServer: AccountsServer) => async (
   try {
     const { email } = req.body;
     const accountsPassword = accountsServer.getServices().password as AccountsPassword;
-    await accountsPassword.sendVerificationEmail(email);
+    try {
+      await accountsPassword.sendVerificationEmail(email);
+    } catch (error) {
+      // If ambiguousErrorMessages is true,
+      // to prevent user enumeration we fail silently in case there is no user attached to this email
+      if (
+        accountsServer.options.ambiguousErrorMessages &&
+        error instanceof AccountsJsError &&
+        error.code === SendVerificationEmailErrors.UserNotFound
+      ) {
+        return res.json(null);
+      }
+      throw error;
+    }
     res.json(null);
   } catch (err) {
     sendError(res, err);

--- a/yarn.lock
+++ b/yarn.lock
@@ -19998,6 +19998,23 @@ ts-jest@26.4.0:
     semver "7.x"
     yargs-parser "20.x"
 
+ts-jest@26.4.4:
+  version "26.4.4"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.4.4.tgz#61f13fb21ab400853c532270e52cc0ed7e502c49"
+  integrity sha512-3lFWKbLxJm34QxyVNNCgXX1u4o/RV0myvA2y2Bxm46iGIjKlaY0own9gIckbjZJPn+WaJEnfPPJ20HHGpoq4yg==
+  dependencies:
+    "@types/jest" "26.x"
+    bs-logger "0.x"
+    buffer-from "1.x"
+    fast-json-stable-stringify "2.x"
+    jest-util "^26.1.0"
+    json5 "2.x"
+    lodash.memoize "4.x"
+    make-error "1.x"
+    mkdirp "1.x"
+    semver "7.x"
+    yargs-parser "20.x"
+
 ts-log@2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/ts-log/-/ts-log-2.1.4.tgz#063c5ad1cbab5d49d258d18015963489fb6fb59a"


### PR DESCRIPTION
BREAKING CHANGE: calling `password.sendVerificationEmail ` will not hide the error anymore if the user is not found when `ambiguousErrorMessages` is true, this error will now be hidden by the transport layer (rest-express, graphql).
**Only a breaking change if** you expose `password. sendVerificationEmail ` to your users without using the one of the transport layers.

This change is made to make the service a bit more "dumb" and to allow to call this function server side and get the error in case the user is not found.