### PR TITLE
chore!: remove the database `setResetPassword` method

### DIFF
--- a/packages/database-manager/__tests__/database-manager.ts
+++ b/packages/database-manager/__tests__/database-manager.ts
@@ -104,10 +104,6 @@ export default class Database {
     return this.name;
   }
 
-  public setResetPassword() {
-    return this.name;
-  }
-
   public setUserDeactivated() {
     return this.name;
   }
@@ -236,12 +232,6 @@ describe('DatabaseManager', () => {
 
   it('addResetPasswordToken should be called on sessionStorage', () => {
     expect(databaseManager.addResetPasswordToken('userId', 'email', 'token', 'reason')).toBe(
-      'userStorage'
-    );
-  });
-
-  it('setResetPassword should be called on sessionStorage', () => {
-    expect(databaseManager.setResetPassword('userId', 'email', 'password', 'token')).toBe(
       'userStorage'
     );
   });

--- a/packages/database-manager/src/database-manager.ts
+++ b/packages/database-manager/src/database-manager.ts
@@ -150,12 +150,7 @@ export class DatabaseManager implements DatabaseInterface {
     return this.userStorage.addResetPasswordToken.bind(this.userStorage);
   }
 
-  // Return the setResetPassword function from the userStorage
-  public get setResetPassword(): DatabaseInterface['setResetPassword'] {
-    return this.userStorage.setResetPassword.bind(this.userStorage);
-  }
-
-  // Return the setResetPassword function from the userStorage
+  // Return the setUserDeactivated function from the userStorage
   public get setUserDeactivated(): DatabaseInterface['setUserDeactivated'] {
     return this.userStorage.setUserDeactivated.bind(this.userStorage);
   }

--- a/packages/database-mongo-password/src/mongo-password.ts
+++ b/packages/database-mongo-password/src/mongo-password.ts
@@ -422,9 +422,4 @@ export class MongoServicePassword implements DatabaseInterfaceServicePassword {
       }
     );
   }
-
-  // TODO delete this function?
-  public async setResetPassword(userId: string, email: string, newPassword: string): Promise<void> {
-    await this.setPassword(userId, newPassword);
-  }
 }

--- a/packages/database-mongo/__tests__/index.ts
+++ b/packages/database-mongo/__tests__/index.ts
@@ -848,20 +848,6 @@ describe('Mongo', () => {
     });
   });
 
-  describe('setResetPassword', () => {
-    it('should change password', async () => {
-      const newPassword = 'newpass';
-      const userId = await databaseTests.database.createUser(user);
-      await delay(10);
-      await databaseTests.database.setResetPassword(userId, 'toto', newPassword);
-      const retUser = await databaseTests.database.findUserById(userId);
-      const services: any = retUser!.services;
-      expect(services.password.bcrypt).toBeTruthy();
-      expect(services.password.bcrypt).toEqual(newPassword);
-      expect((retUser as any).createdAt).not.toEqual((retUser as any).updatedAt);
-    });
-  });
-
   describe('setUserDeactivated', () => {
     // eslint-disable-next-line jest/expect-expect
     it('should not convert id', async () => {

--- a/packages/database-mongo/src/mongo.ts
+++ b/packages/database-mongo/src/mongo.ts
@@ -133,10 +133,6 @@ export class Mongo implements DatabaseInterface {
     return this.servicePassword.addResetPasswordToken(userId, email, token, reason);
   }
 
-  public async setResetPassword(userId: string, email: string, newPassword: string): Promise<void> {
-    return this.servicePassword.setResetPassword(userId, email, newPassword);
-  }
-
   public async createSession(
     userId: string,
     token: string,

--- a/packages/database-typeorm/src/typeorm.ts
+++ b/packages/database-typeorm/src/typeorm.ts
@@ -271,17 +271,6 @@ export class AccountsTypeorm implements DatabaseInterface {
     );
   }
 
-  public async setResetPassword(
-    userId: string,
-    email: string,
-    newPassword: string,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    token?: string
-  ): Promise<void> {
-    await this.setPassword(userId, newPassword);
-    await this.unsetService(userId, 'password.reset');
-  }
-
   public async addEmail(userId: string, newEmail: string, verified: boolean): Promise<void> {
     const user = await this.findUserById(userId);
     if (user) {

--- a/packages/oauth/__tests__/accounts-oauth.ts
+++ b/packages/oauth/__tests__/accounts-oauth.ts
@@ -19,7 +19,6 @@ const mockStore = {
   findUserByResetPasswordToken: jest.fn(),
   setPassword: jest.fn(),
   addResetPasswordToken: jest.fn(),
-  setResetPassword: jest.fn(),
   addEmail: jest.fn(),
   removeEmail: jest.fn(),
   verifyEmail: jest.fn(),

--- a/packages/password/__tests__/accounts-password.ts
+++ b/packages/password/__tests__/accounts-password.ts
@@ -240,12 +240,10 @@ describe('AccountsPassword', () => {
     it('validate user email if enrolled', async () => {
       const findUserByResetPasswordToken = jest.fn(() => Promise.resolve(validUserEnroll));
       password.isTokenExpired = jest.fn(() => false);
-      const setResetPassword = jest.fn(() => Promise.resolve());
       const invalidateAllSessions = jest.fn(() => Promise.resolve());
       const verifyEmail = jest.fn(() => Promise.resolve());
       password.setStore({
         findUserByResetPasswordToken,
-        setResetPassword,
         invalidateAllSessions,
         verifyEmail,
       } as any);
@@ -260,7 +258,6 @@ describe('AccountsPassword', () => {
       } as any;
       set(password.server, 'options.emailTemplates', {});
       await password.resetPassword(token, newPassword, connectionInfo);
-      expect(setResetPassword.mock.calls.length).toBe(1);
       expect(verifyEmail.mock.calls.length).toBe(1);
       expect(invalidateAllSessions.mock.calls[0]).toMatchSnapshot();
     });
@@ -268,11 +265,9 @@ describe('AccountsPassword', () => {
     it('reset password and invalidate all sessions', async () => {
       const findUserByResetPasswordToken = jest.fn(() => Promise.resolve(validUser));
       const isTokenExpired = jest.fn(() => false);
-      const setResetPassword = jest.fn(() => Promise.resolve());
       const invalidateAllSessions = jest.fn(() => Promise.resolve());
       password.setStore({
         findUserByResetPasswordToken,
-        setResetPassword,
         invalidateAllSessions,
       } as any);
       const prepareMail = jest.fn(() => Promise.resolve());
@@ -289,7 +284,6 @@ describe('AccountsPassword', () => {
       set(password.server, 'options.emailTemplates', {});
       const loginResult = await password.resetPassword(token, newPassword, connectionInfo);
       expect(loginResult).toBeNull();
-      expect(setResetPassword.mock.calls.length).toBe(1);
       expect(invalidateAllSessions.mock.calls[0]).toMatchSnapshot();
     });
 
@@ -308,11 +302,9 @@ describe('AccountsPassword', () => {
         },
       };
       const loginWithUser = jest.fn(() => Promise.resolve(exampleLoginResult));
-      const setResetPassword = jest.fn(() => Promise.resolve());
       const invalidateAllSessions = jest.fn(() => Promise.resolve());
       tmpAccountsPassword.setStore({
         findUserByResetPasswordToken,
-        setResetPassword,
         invalidateAllSessions,
       } as any);
       const prepareMail = jest.fn(() => Promise.resolve());
@@ -333,7 +325,6 @@ describe('AccountsPassword', () => {
         connectionInfo
       );
       expect(loginResult).toEqual(exampleLoginResult);
-      expect(setResetPassword.mock.calls.length).toBe(1);
       expect(invalidateAllSessions.mock.calls[0]).toMatchSnapshot();
     });
   });

--- a/packages/password/__tests__/accounts-password.ts
+++ b/packages/password/__tests__/accounts-password.ts
@@ -240,10 +240,14 @@ describe('AccountsPassword', () => {
     it('validate user email if enrolled', async () => {
       const findUserByResetPasswordToken = jest.fn(() => Promise.resolve(validUserEnroll));
       password.isTokenExpired = jest.fn(() => false);
+      const setPassword = jest.fn(() => Promise.resolve());
+      const removeAllResetPasswordTokens = jest.fn(() => Promise.resolve());
       const invalidateAllSessions = jest.fn(() => Promise.resolve());
       const verifyEmail = jest.fn(() => Promise.resolve());
       password.setStore({
         findUserByResetPasswordToken,
+        setPassword,
+        removeAllResetPasswordTokens,
         invalidateAllSessions,
         verifyEmail,
       } as any);
@@ -258,6 +262,8 @@ describe('AccountsPassword', () => {
       } as any;
       set(password.server, 'options.emailTemplates', {});
       await password.resetPassword(token, newPassword, connectionInfo);
+      expect(setPassword.mock.calls.length).toBe(1);
+      expect(removeAllResetPasswordTokens.mock.calls.length).toBe(1);
       expect(verifyEmail.mock.calls.length).toBe(1);
       expect(invalidateAllSessions.mock.calls[0]).toMatchSnapshot();
     });
@@ -265,9 +271,13 @@ describe('AccountsPassword', () => {
     it('reset password and invalidate all sessions', async () => {
       const findUserByResetPasswordToken = jest.fn(() => Promise.resolve(validUser));
       const isTokenExpired = jest.fn(() => false);
+      const setPassword = jest.fn(() => Promise.resolve());
+      const removeAllResetPasswordTokens = jest.fn(() => Promise.resolve());
       const invalidateAllSessions = jest.fn(() => Promise.resolve());
       password.setStore({
         findUserByResetPasswordToken,
+        setPassword,
+        removeAllResetPasswordTokens,
         invalidateAllSessions,
       } as any);
       const prepareMail = jest.fn(() => Promise.resolve());
@@ -284,6 +294,8 @@ describe('AccountsPassword', () => {
       set(password.server, 'options.emailTemplates', {});
       const loginResult = await password.resetPassword(token, newPassword, connectionInfo);
       expect(loginResult).toBeNull();
+      expect(setPassword.mock.calls.length).toBe(1);
+      expect(removeAllResetPasswordTokens.mock.calls.length).toBe(1);
       expect(invalidateAllSessions.mock.calls[0]).toMatchSnapshot();
     });
 
@@ -302,9 +314,13 @@ describe('AccountsPassword', () => {
         },
       };
       const loginWithUser = jest.fn(() => Promise.resolve(exampleLoginResult));
+      const setPassword = jest.fn(() => Promise.resolve());
+      const removeAllResetPasswordTokens = jest.fn(() => Promise.resolve());
       const invalidateAllSessions = jest.fn(() => Promise.resolve());
       tmpAccountsPassword.setStore({
         findUserByResetPasswordToken,
+        setPassword,
+        removeAllResetPasswordTokens,
         invalidateAllSessions,
       } as any);
       const prepareMail = jest.fn(() => Promise.resolve());
@@ -325,6 +341,8 @@ describe('AccountsPassword', () => {
         connectionInfo
       );
       expect(loginResult).toEqual(exampleLoginResult);
+      expect(setPassword.mock.calls.length).toBe(1);
+      expect(removeAllResetPasswordTokens.mock.calls.length).toBe(1);
       expect(invalidateAllSessions.mock.calls[0]).toMatchSnapshot();
     });
   });

--- a/packages/password/package.json
+++ b/packages/password/package.json
@@ -31,10 +31,11 @@
     "@accounts/server": "^0.30.0",
     "@accounts/types": "^0.30.0",
     "@types/bcryptjs": "2.4.2",
-    "@types/jest": "25.2.3",
+    "@types/jest": "26.0.19",
     "@types/lodash": "4.14.157",
     "@types/node": "14.0.14",
-    "jest": "26.0.1",
+    "jest": "26.6.3",
+    "ts-jest": "26.4.4",
     "rimraf": "3.0.2"
   },
   "peerDependencies": {

--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -347,8 +347,9 @@ export default class AccountsPassword<CustomUser extends User = User>
     }
 
     const password = await this.options.hashPassword(newPassword);
-    // Change the user password and remove the old token
-    await this.db.setResetPassword(user.id, resetTokenRecord.address, password, token);
+    // Change the user password and remove the other reset tokens
+    await this.db.setPassword(user.id, password);
+    await this.db.removeAllResetPasswordTokens(user.id);
 
     await this.server.getHooks().emit(ServerHooks.ResetPasswordSuccess, user);
 

--- a/packages/types/src/types/services/password/database-interface.ts
+++ b/packages/types/src/types/services/password/database-interface.ts
@@ -25,13 +25,6 @@ export interface DatabaseInterfaceServicePassword<CustomUser extends User = User
     reason: string
   ): Promise<void>;
 
-  setResetPassword(
-    userId: string,
-    email: string,
-    newPassword: string,
-    token: string
-  ): Promise<void>;
-
   addEmail(userId: string, newEmail: string, verified: boolean): Promise<void>;
 
   removeEmail(userId: string, email: string): Promise<void>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4273,6 +4273,14 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
+"@types/jest@26.0.19":
+  version "26.0.19"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.19.tgz#e6fa1e3def5842ec85045bd5210e9bb8289de790"
+  integrity sha512-jqHoirTG61fee6v6rwbnEuKhpSKih0tuhqeFbCmMmErhtu3BYlOZaXWjffgOstMM4S/3iQD31lI5bGLTrs97yQ==
+  dependencies:
+    jest-diff "^26.0.0"
+    pretty-format "^26.0.0"
+
 "@types/json-schema@*", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6":
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"


### PR DESCRIPTION
BREAKING CHANGE: `db.setResetPassword` has been removed from the database interface as it was just an alias to `db.setPassword`.
If you are using this method, use `setPassword` instead.

Note: if you are using the typeorm adapter, you also need to call `db.removeAllResetPasswordTokens` to keep the same behavior as before.