### PR TITLE
fix(password): update peer dependencies

### DIFF
--- a/packages/password/package.json
+++ b/packages/password/package.json
@@ -39,6 +39,6 @@
     "rimraf": "3.0.2"
   },
   "peerDependencies": {
-    "@accounts/server": "^0.19.0"
+    "@accounts/server": "^0.30.0"
   }
 }


### PR DESCRIPTION
I'm currently seeing 

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: level-up-tutorials@3.0.0
npm ERR! Found: @accounts/server@0.30.0
npm ERR! node_modules/@accounts/server
npm ERR!   @accounts/server@"^0.30.0" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer @accounts/server@"^0.19.0" from @accounts/password@0.30.0
npm ERR! node_modules/@accounts/password
npm ERR!   @accounts/password@"^0.30.0" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
npm ERR! See /Users/scotttolinski/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/scotttolinski/.npm/_logs/2020-12-20T00_44_11_275Z-debug.log
e Error: Command failed with exit code 1: npm install
```

The peerDependencies still had the previous version.