### PR TITLE
fix(mongo): put mongodb types in dependencies

### DIFF
--- a/packages/database-mongo-password/package.json
+++ b/packages/database-mongo-password/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@types/jest": "26.0.15",
-    "@types/mongodb": "^3.5.33",
+    "@types/mongodb": "3.6.6",
     "@types/node": "14.14.9",
     "jest": "26.6.3",
     "ts-jest": "26.5.0"

--- a/packages/database-mongo-password/package.json
+++ b/packages/database-mongo-password/package.json
@@ -33,7 +33,8 @@
   },
   "devDependencies": {
     "@types/jest": "26.0.15",
-    "@types/mongodb": "3.5.33",
+    "@types/mongodb": "^3.5.33",
+
     "@types/node": "14.14.9",
     "jest": "26.6.3",
     "ts-jest": "26.4.0"

--- a/packages/database-mongo-password/package.json
+++ b/packages/database-mongo-password/package.json
@@ -37,7 +37,6 @@
   "devDependencies": {
     "@types/jest": "26.0.15",
     "@types/mongodb": "^3.5.33",
-
     "@types/node": "14.14.9",
     "jest": "26.6.3",
     "ts-jest": "26.5.0"

--- a/packages/database-mongo-sessions/package.json
+++ b/packages/database-mongo-sessions/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@types/jest": "26.0.15",
-    "@types/mongodb": "^3.5.33",
+    "@types/mongodb": "3.6.6",
     "@types/node": "14.14.9",
     "jest": "26.6.3",
     "ts-jest": "26.5.0"

--- a/packages/database-mongo-sessions/package.json
+++ b/packages/database-mongo-sessions/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@types/jest": "26.0.15",
-    "@types/mongodb": "3.5.33",
+    "@types/mongodb": "^3.5.33",
     "@types/node": "14.14.9",
     "jest": "26.6.3",
     "ts-jest": "26.4.0"

--- a/packages/database-mongo/package.json
+++ b/packages/database-mongo/package.json
@@ -32,7 +32,7 @@
     "@accounts/types": "^0.30.0",
     "@accounts/mongo-password": "^0.30.0",
     "@accounts/mongo-sessions": "^0.30.0",
-    "@types/mongodb": "3.5.33",
+    "@types/mongodb": "^3.5.33",
     "mongodb": "^3.4.1",
     "tslib": "2.0.3"
   },

--- a/packages/database-mongo/package.json
+++ b/packages/database-mongo/package.json
@@ -29,9 +29,9 @@
   "author": "Leo Pradel",
   "license": "MIT",
   "dependencies": {
-    "@accounts/types": "^0.31.1",
     "@accounts/mongo-password": "^0.31.1",
     "@accounts/mongo-sessions": "^0.31.1",
+    "@accounts/types": "^0.31.1",
     "@types/mongodb": "^3.5.33",
     "mongodb": "^3.4.1",
     "tslib": "2.0.3"

--- a/packages/database-mongo/package.json
+++ b/packages/database-mongo/package.json
@@ -32,13 +32,13 @@
     "@accounts/types": "^0.30.0",
     "@accounts/mongo-password": "^0.30.0",
     "@accounts/mongo-sessions": "^0.30.0",
+    "@types/mongodb": "3.5.33",
     "mongodb": "^3.4.1",
     "tslib": "2.0.3"
   },
   "devDependencies": {
     "@accounts/database-tests": "^0.30.0",
     "@types/jest": "26.0.15",
-    "@types/mongodb": "3.5.33",
     "@types/node": "14.14.9",
     "jest": "26.6.3",
     "ts-jest": "26.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4214,10 +4214,10 @@
     "@types/bson" "*"
     "@types/node" "*"
 
-"@types/mongodb@3.5.33":
-  version "3.5.33"
-  resolved "https://registry.yarnpkg.com/@types/mongodb/-/mongodb-3.5.33.tgz#1084c3004a426df11b5a985641e7f58d7ceb52a6"
-  integrity sha512-biMkaYFyUP8jNczbi2BgtvVfiEtPZ+NTf+Jz4LmsQjO+Zk+kx1WNjz8gNArWlA/5DXVwMVWgIFtbj6Tslt1yWw==
+"@types/mongodb@3.6.6", "@types/mongodb@^3.5.33":
+  version "3.6.6"
+  resolved "https://registry.yarnpkg.com/@types/mongodb/-/mongodb-3.6.6.tgz#d62300927564e03daa08794eb207ff4f760f9014"
+  integrity sha512-ghYevKiSh/TGk2MAwSRZP7T1ilR9Pw8Fa7pT9GGVGZPUsWKdZjZ4G6LG3MqK2iXKdNba994F8W9ikA+qx2Eo3A==
   dependencies:
     "@types/bson" "*"
     "@types/node" "*"


### PR DESCRIPTION
The `@accounts/mongo` package types depend on the `mongodb` types. Doesn't work with Yarn 2 PnP at the moment.