### PR TITLE
fix(server): fix impersonation token

### DIFF
--- a/packages/server/__tests__/account-server.ts
+++ b/packages/server/__tests__/account-server.ts
@@ -1316,6 +1316,11 @@ describe('AccountsServer', () => {
           impersonationAuthorize: async (userObject, impersonateToUser) => {
             return userObject.id === user.id && impersonateToUser === impersonatedUser;
           },
+          tokenCreator: {
+            createToken: async () => {
+              return '123';
+            },
+          },
         },
         {}
       );
@@ -1342,7 +1347,7 @@ describe('AccountsServer', () => {
       );
       expect(res).toEqual({
         authorized: true,
-        tokens: { token: '001', isImpersonated: true },
+        tokens: { token: '123', isImpersonated: true },
         user: impersonatedUser,
       });
       expect(createSession).toHaveBeenCalledWith(

--- a/packages/server/src/accounts-server.ts
+++ b/packages/server/src/accounts-server.ts
@@ -304,13 +304,13 @@ Please set ambiguousErrorMessages to false to be able to use autologin.`
         return { authorized: false };
       }
 
-      const token = generateRandomToken();
+      const token = await this.createSessionToken(impersonatedUser);
       const newSessionId = await this.db.createSession(impersonatedUser.id, token, infos, {
         impersonatorUserId: user.id,
       });
 
       const impersonationTokens = await this.createTokens({
-        token: newSessionId,
+        token,
         isImpersonated: true,
         user,
       });
@@ -323,6 +323,7 @@ Please set ambiguousErrorMessages to false to be able to use autologin.`
       await this.hooks.emit(ServerHooks.ImpersonationSuccess, {
         user,
         impersonationResult,
+        sessionId: newSessionId,
       });
 
       return impersonationResult;


### PR DESCRIPTION
The access token received after an impersonation is wrongly encoded with
the session id instead of the session token. This causes all subsequent
session operations with the new token to fail.

This PR fixes this bug and has the tests updated as well to reflect
this change.

Fixes: #1094