### PR TITLE
fix(client): invalidate session when stopping impersonation

### DIFF
--- a/packages/client/src/accounts-client.ts
+++ b/packages/client/src/accounts-client.ts
@@ -174,6 +174,7 @@ export class AccountsClient {
   public async stopImpersonation(): Promise<void> {
     const tokens = await this.getTokens(true);
     if (tokens) {
+      await this.logout();
       await this.setTokens(tokens);
       await this.clearTokens(true);
     }


### PR DESCRIPTION
The session created when impersonating another user is is not
invalidated when the client stops impersonation. This PR adds a call to
logout to properly invalidate the session before restoring the original
tokens from storage.

Fixes: #1096