### PR TITLE
fix!: change target to es2018 for server packages

### DIFF
--- a/packages/apollo-link-accounts/tsconfig.json
+++ b/packages/apollo-link-accounts/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./lib",
-    "importHelpers": true
+    "importHelpers": true,
+    "target": "es5"
   },
   "exclude": ["node_modules", "__tests__", "lib"]
 }

--- a/packages/client-password/tsconfig.json
+++ b/packages/client-password/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./lib",
-    "importHelpers": true
+    "importHelpers": true,
+    "target": "es5"
   },
   "exclude": ["node_modules", "__tests__", "lib"]
 }

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./lib",
-    "importHelpers": true
+    "importHelpers": true,
+    "target": "es5"
   },
   "exclude": ["node_modules", "__tests__", "lib"]
 }

--- a/packages/graphql-client/tsconfig.json
+++ b/packages/graphql-client/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./lib",
-    "importHelpers": true
+    "importHelpers": true,
+    "target": "es5"
   },
   "exclude": ["node_modules", "__tests__", "lib"]
 }

--- a/packages/rest-client/tsconfig.json
+++ b/packages/rest-client/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./lib",
-    "importHelpers": true
+    "importHelpers": true,
+    "target": "es5"
   },
   "exclude": ["node_modules", "__tests__", "lib"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2018",
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,


### PR DESCRIPTION
BREAKING CHANGE: Drop support for node 8. Minimum node version is node 10.

Closes #1091