### PR TITLE
chore(password)!: await sendVerificationEmail during user signup

### DIFF
--- a/packages/password/src/accounts-password.ts
+++ b/packages/password/src/accounts-password.ts
@@ -1,4 +1,4 @@
-import { trim, isEmpty, pick, isString, isPlainObject, find, includes, defer } from 'lodash';
+import { trim, isEmpty, pick, isString, isPlainObject, find, includes } from 'lodash';
 import {
   User,
   LoginUserIdentity,
@@ -641,11 +641,9 @@ export default class AccountsPassword<CustomUser extends User = User>
       const userRecord = (await this.db.findUserById(userId)) as User;
       await this.server.getHooks().emit(ServerHooks.CreateUserSuccess, userRecord);
 
-      defer(async () => {
-        if (this.options.sendVerificationEmailAfterSignup && user.email) {
-          this.sendVerificationEmail(user.email);
-        }
-      });
+      if (this.options.sendVerificationEmailAfterSignup && user.email) {
+        await this.sendVerificationEmail(user.email);
+      }
 
       return userId;
     } catch (e) {


### PR DESCRIPTION
BREAKING CHANGE: The createUser function now await `sendVerificationEmail` only if `sendVerificationEmailAfterSignup` is true. This change was made to be able to run this function in lambda.