### PR TITLE
chore(server)!: simplify userObjectSanitizer option

### DIFF
--- a/packages/server/__tests__/account-server.ts
+++ b/packages/server/__tests__/account-server.ts
@@ -1381,7 +1381,14 @@ describe('AccountsServer', () => {
         {
           db: db as any,
           tokenSecret: 'secret1',
-          userObjectSanitizer: (user, omit) => omit(user, ['username']),
+          userObjectSanitizer: (user) => {
+            const {
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              username,
+              ...sanitizedUser
+            } = user;
+            return sanitizedUser;
+          },
         },
         {}
       );

--- a/packages/server/src/accounts-server.ts
+++ b/packages/server/src/accounts-server.ts
@@ -1,4 +1,4 @@
-import { pick, omit, isString, merge } from 'lodash';
+import { omit, isString, merge } from 'lodash';
 import * as jwt from 'jsonwebtoken';
 import Emittery from 'emittery';
 import {
@@ -611,7 +611,7 @@ Please set ambiguousErrorMessages to false to be able to use autologin.`
       ? this.internalUserSanitizer(user)
       : user;
 
-    return userObjectSanitizer(baseUser, omit as any, pick as any);
+    return userObjectSanitizer(baseUser) as CustomUser;
   }
 
   private internalUserSanitizer(user: CustomUser): CustomUser {

--- a/packages/server/src/types/accounts-server-options.ts
+++ b/packages/server/src/types/accounts-server-options.ts
@@ -1,7 +1,6 @@
 import * as jwt from 'jsonwebtoken';
 import { User, DatabaseInterface, Session } from '@accounts/types';
 import { EmailTemplatesType } from './email-templates-type';
-import { UserObjectSanitizerFunction } from './user-object-sanitizer-function';
 import { PrepareMailFunction } from './prepare-mail-function';
 import { SendMailType } from './send-mail-type';
 import { TokenCreator } from './token-creator';
@@ -24,7 +23,7 @@ export interface AccountsServerOptions<CustomUser extends User = User> {
     refreshToken?: jwt.SignOptions;
   };
   emailTemplates?: EmailTemplatesType;
-  userObjectSanitizer?: UserObjectSanitizerFunction;
+  userObjectSanitizer?: (user: CustomUser) => CustomUser;
   impersonationAuthorize?: (user: User, impersonateToUser: User) => Promise<any>;
   /**
    * Use this function if you want to cancel the current session to be resumed.

--- a/packages/server/src/types/user-object-sanitizer-function.ts
+++ b/packages/server/src/types/user-object-sanitizer-function.ts
@@ -1,7 +1,0 @@
-import { User } from '@accounts/types';
-
-export type UserObjectSanitizerFunction = (
-  userObject: User,
-  omitFunction: (userDoc: object, fields: string[]) => User,
-  pickFunction: (userDoc: object, fields: string[]) => User
-) => any;


### PR DESCRIPTION
BREAKING CHANGE: Change the option `userObjectSanitizer` parameters. `pick` and `omit` are removed, if you are relying on them, you can import them from lodash directly. 