### PR TITLE
chore: Update peer dependencies to the latest version

### DIFF
--- a/packages/graphql-api/package.json
+++ b/packages/graphql-api/package.json
@@ -33,9 +33,9 @@
   },
   "homepage": "https://github.com/js-accounts/graphql-api",
   "peerDependencies": {
-    "@accounts/password": "^0.30.0",
-    "@accounts/server": "^0.30.0",
-    "@accounts/types": "^0.30.0",
+    "@accounts/password": "^0.31.1",
+    "@accounts/server": "^0.31.1",
+    "@accounts/types": "^0.31.1",
     "@graphql-modules/core": "0.7.17",
     "graphql": "^14.6.0 || ^15.0.0",
     "graphql-tag": "^2.10.0"

--- a/packages/password/package.json
+++ b/packages/password/package.json
@@ -39,6 +39,6 @@
     "ts-jest": "26.5.0"
   },
   "peerDependencies": {
-    "@accounts/server": "^0.30.0"
+    "@accounts/server": "^0.31.1"
   }
 }


### PR DESCRIPTION
The `peerDependencies` were a little outdated. Since the version is still 0...., the `^` is behaving like a `~`. So while installing, the install was not working because of broken dependency tree.