### PR TITLE
fix: repo links in graphql-api package.json

### DIFF
--- a/.changeset/eighty-zoos-glow.md
+++ b/.changeset/eighty-zoos-glow.md
@@ -1,0 +1,5 @@
+---
+"@accounts/graphql-api": patch
+---
+
+Fix repo links in package.json

--- a/packages/graphql-api/package.json
+++ b/packages/graphql-api/package.json
@@ -24,14 +24,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/js-accounts/graphql.git"
+    "url": "https://github.com/js-accounts/accounts"
   },
   "author": "David Yahalomi",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/js-accounts/graphql-api/issues"
+    "url": "https://github.com/js-accounts/accounts/issues"
   },
-  "homepage": "https://github.com/js-accounts/graphql-api",
+  "homepage": "https://github.com/js-accounts/accounts",
   "peerDependencies": {
     "@accounts/magic-link": "^0.1.0",
     "@accounts/password": "^0.32.0",


### PR DESCRIPTION
Currently when you go to the page on NPM for this package it points to the old archived version which is confusing when the code actually lives here