### PR TITLE
fix: check `convertSessionIdToMongoObjectId` before using `idProvider`

### DIFF
--- a/.changeset/rotten-rules-repair.md
+++ b/.changeset/rotten-rules-repair.md
@@ -1,0 +1,5 @@
+---
+'@accounts/mongo-sessions': patch
+---
+
+The configuration option of convertSessionIdToMongoObjectId is now checked when using idProvider

--- a/.changeset/swift-panthers-play.md
+++ b/.changeset/swift-panthers-play.md
@@ -2,4 +2,8 @@
 '@accounts/mongo-sessions': minor
 ---
 
-Changed `idProvider` to `idSessionProvider` in mongo-sessions. If you are using `idProvider` for the creation of a custom identifier for sessions, then you will need to move that logic to a new `idSessionProvider` function in the configuration. Going forward, the `idProvider` will only be used for the creation of user identifiers. This change was made to give more granular control when creating custom identifiers for both sessions and users.
+Changed `idProvider` to `idSessionProvider` in `@mongo-sessions`. This change was made to give more granular control when creating custom identifiers for both sessions and users. The new option generates the _id for new Session objects. Going forward, the `idProvider` will only be used for the creation of user identifiers.
+
+Updated `AccountsMongoOptions` in `@database-mongo` to have the new `idSessionProvider`.
+
+**Migration:** If you are using `idProvider` for the creation of a custom identifier for sessions, then you will need to move that logic to the new `idSessionProvider` function in the configuration.

--- a/.changeset/swift-panthers-play.md
+++ b/.changeset/swift-panthers-play.md
@@ -2,4 +2,4 @@
 '@accounts/mongo-sessions': minor
 ---
 
-Changed idProvider to idSessionProvider in mongo-sessions
+Changed `idProvider` to `idSessionProvider` in mongo-sessions. If you are using `idProvider` for the creation of a custom identifier for sessions, then you will need to move that logic to a new `idSessionProvider` function in the configuration. Going forward, the `idProvider` will only be used for the creation of user identifiers. This change was made to give more granular control when creating custom identifiers for both sessions and users.

--- a/.changeset/swift-panthers-play.md
+++ b/.changeset/swift-panthers-play.md
@@ -1,0 +1,5 @@
+---
+'@accounts/mongo-sessions': minor
+---
+
+Changed idProvider to idSessionProvider in mongo-sessions

--- a/.changeset/swift-panthers-play.md
+++ b/.changeset/swift-panthers-play.md
@@ -5,6 +5,6 @@
 
 Changed `idProvider` to `idSessionProvider` in `@mongo-sessions`. This change was made to give more granular control when creating custom identifiers for both sessions and users. The new option generates the _id for new Session objects. Going forward, the `idProvider` will only be used for the creation of user identifiers.
 
-Updated `AccountsMongoOptions` in `@database-mongo` to have the new `idSessionProvider`.
+Updated `AccountsMongoOptions` in `@mongo` to have the new `idSessionProvider`.
 
 **Migration:** If you are using `idProvider` for the creation of a custom identifier for sessions, then you will need to move that logic to the new `idSessionProvider` function in the configuration.

--- a/.changeset/swift-panthers-play.md
+++ b/.changeset/swift-panthers-play.md
@@ -1,5 +1,6 @@
 ---
 '@accounts/mongo-sessions': minor
+'@accounts/database-mongo': minor
 ---
 
 Changed `idProvider` to `idSessionProvider` in `@mongo-sessions`. This change was made to give more granular control when creating custom identifiers for both sessions and users. The new option generates the _id for new Session objects. Going forward, the `idProvider` will only be used for the creation of user identifiers.

--- a/.changeset/swift-panthers-play.md
+++ b/.changeset/swift-panthers-play.md
@@ -1,6 +1,6 @@
 ---
 '@accounts/mongo-sessions': minor
-'@accounts/database-mongo': minor
+'@accounts/mongo': minor
 ---
 
 Changed `idProvider` to `idSessionProvider` in `@mongo-sessions`. This change was made to give more granular control when creating custom identifiers for both sessions and users. The new option generates the _id for new Session objects. Going forward, the `idProvider` will only be used for the creation of user identifiers.

--- a/packages/database-mongo-sessions/__tests__/mongo-sessions.ts
+++ b/packages/database-mongo-sessions/__tests__/mongo-sessions.ts
@@ -119,7 +119,7 @@ describe('MongoSessions', () => {
     it('using id provider on create session', async () => {
       const mongoSessions = new MongoSessions({
         database,
-        idProvider: () => new ObjectID().toHexString(),
+        idSessionProvider: () => new ObjectID().toHexString(),
         convertSessionIdToMongoObjectId: false,
       });
       const sessionId = await mongoSessions.createSession(session.userId, 'token', {
@@ -145,18 +145,6 @@ describe('MongoSessions', () => {
       const ret = await mongoSessions.findSessionById(sessionId);
       expect((ret as any)._id).toBeTruthy();
       expect((ret as any)._id).toBeInstanceOf(ObjectID);
-    });
-
-    it('using id provider should show deprecation warning', async () => {
-      const consoleSpy = jest.spyOn(console, 'warn');
-      new MongoSessions({
-        database,
-        convertSessionIdToMongoObjectId: false,
-        idProvider: () => `someprefix|${new ObjectID().toString()}`,
-      });
-      expect(consoleSpy).toBeCalledTimes(1);
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Deprecation'));
-      consoleSpy.mockRestore();
     });
 
     it('using both idSessionProvider and convertToMongoObject Id should show warning', async () => {

--- a/packages/database-mongo-sessions/__tests__/mongo-sessions.ts
+++ b/packages/database-mongo-sessions/__tests__/mongo-sessions.ts
@@ -136,7 +136,7 @@ describe('MongoSessions', () => {
       const mongoSessions = new MongoSessions({
         database,
         convertSessionIdToMongoObjectId: true,
-        idProvider: () => `someprefix|${new ObjectID().toString()}`,
+        idSessionProvider: () => `someprefix|${new ObjectID().toString()}`,
       });
       const sessionId = await mongoSessions.createSession(session.userId, 'token', {
         ip: session.ip,
@@ -145,6 +145,30 @@ describe('MongoSessions', () => {
       const ret = await mongoSessions.findSessionById(sessionId);
       expect((ret as any)._id).toBeTruthy();
       expect((ret as any)._id).toBeInstanceOf(ObjectID);
+    });
+
+    it('using id provider should show deprecation warning', async () => {
+      const consoleSpy = jest.spyOn(console, 'warn');
+      new MongoSessions({
+        database,
+        convertSessionIdToMongoObjectId: false,
+        idProvider: () => `someprefix|${new ObjectID().toString()}`,
+      });
+      expect(consoleSpy).toBeCalledTimes(1);
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Deprecation'));
+      consoleSpy.mockRestore();
+    });
+
+    it('using both idSessionProvider and convertToMongoObject Id should show warning', async () => {
+      const consoleSpy = jest.spyOn(console, 'warn');
+      new MongoSessions({
+        database,
+        convertSessionIdToMongoObjectId: true,
+        idSessionProvider: () => `someprefix|${new ObjectID().toString()}`,
+      });
+      expect(consoleSpy).toBeCalledTimes(1);
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('set both'));
+      consoleSpy.mockRestore();
     });
   });
 

--- a/packages/database-mongo-sessions/__tests__/mongo-sessions.ts
+++ b/packages/database-mongo-sessions/__tests__/mongo-sessions.ts
@@ -131,6 +131,21 @@ describe('MongoSessions', () => {
       expect((ret as any)._id).not.toEqual(new ObjectID((ret as any)._id));
       expect((ret as any)._id).toEqual(new ObjectID((ret as any)._id).toHexString());
     });
+
+    it('using id provider and convertSessionIdToMongoObjectId on create session', async () => {
+      const mongoSessions = new MongoSessions({
+        database,
+        convertSessionIdToMongoObjectId: true,
+        idProvider: () => `someprefix|${new ObjectID().toString()}`,
+      });
+      const sessionId = await mongoSessions.createSession(session.userId, 'token', {
+        ip: session.ip,
+        userAgent: session.userAgent,
+      });
+      const ret = await mongoSessions.findSessionById(sessionId);
+      expect((ret as any)._id).toBeTruthy();
+      expect((ret as any)._id).toBeInstanceOf(ObjectID);
+    });
   });
 
   describe('findSessionById', () => {

--- a/packages/database-mongo-sessions/src/mongo-sessions.ts
+++ b/packages/database-mongo-sessions/src/mongo-sessions.ts
@@ -33,8 +33,7 @@ export interface MongoSessionsOptions {
    */
   idSessionProvider?: () => string | object;
   /**
-   * Function that generate the id for new objects.
-   * @deprecated - please use `idSessionProvider` instead.
+   * Function that generate the id for new User objects.
    */
   idProvider?: () => string | object;
   /**
@@ -69,20 +68,12 @@ export class MongoSessions implements DatabaseInterfaceSessions {
       timestamps: { ...defaultOptions.timestamps, ...options.timestamps },
     };
 
-    if (typeof this.options.idProvider === 'function') {
-      this.options.idSessionProvider = this.options.idProvider;
-      console.warn(
-        `Deprecation Warning: The option "options.idProvider" is deprecated. 
-        Setting it to "options.idSessionProvider," please change your configuration, as "options.idProvider" will be removed in a future release.`
-      );
-    }
-
     if (
       typeof this.options.idSessionProvider === 'function' &&
       this.options.convertSessionIdToMongoObjectId
     ) {
-      console.warn(`You have set both "options.idSessionProvider" and "options.convertSessionIdToMongoObjectId = false" which will cause your "options.idSessionProvider" to be ignored. 
-      In order to fix this warning change "options.convertSessionIdToMongoObjectId" to "true" or remove your "options.idSessionProvider" from the configuration.
+      console.warn(`You have set both "options.idSessionProvider" and "options.convertSessionIdToMongoObjectId = true" which will cause your "options.idSessionProvider" to be ignored. 
+      In order to fix this warning change "options.convertSessionIdToMongoObjectId" to "false" or remove your "options.idSessionProvider" from the configuration.
       `);
     }
 

--- a/packages/database-mongo-sessions/src/mongo-sessions.ts
+++ b/packages/database-mongo-sessions/src/mongo-sessions.ts
@@ -102,7 +102,7 @@ export class MongoSessions implements DatabaseInterfaceSessions {
       [this.options.timestamps.updatedAt]: this.options.dateProvider(),
     };
 
-    if (this.options.idProvider) {
+    if (this.options.idProvider && !this.options.convertSessionIdToMongoObjectId) {
       session._id = this.options.idProvider();
     }
 

--- a/packages/database-mongo/__tests__/database-tests.ts
+++ b/packages/database-mongo/__tests__/database-tests.ts
@@ -44,7 +44,8 @@ export class DatabaseTests {
 runDatabaseTests(
   new DatabaseTests({
     convertUserIdToMongoObjectId: false,
-    convertSessionIdToMongoObjectId: false,
     idProvider: () => new mongodb.ObjectId().toString(),
+    convertSessionIdToMongoObjectId: false,
+    idSessionProvider: () => new mongodb.ObjectId().toString(),
   })
 );

--- a/packages/database-mongo/__tests__/index.ts
+++ b/packages/database-mongo/__tests__/index.ts
@@ -590,7 +590,7 @@ describe('Mongo', () => {
 
     it('using id provider on create session', async () => {
       const mongoTestOptions = new Mongo(databaseTests.db, {
-        idProvider: () => new ObjectID().toHexString(),
+        idSessionProvider: () => new ObjectID().toHexString(),
         convertSessionIdToMongoObjectId: false,
       });
       const sessionId = await mongoTestOptions.createSession(session.userId, 'token', {

--- a/packages/database-mongo/src/types/index.ts
+++ b/packages/database-mongo/src/types/index.ts
@@ -33,6 +33,12 @@ export interface AccountsMongoOptions {
    */
   caseSensitiveUserName?: boolean;
   /**
+   * Function that generates the _id for new Session objects.
+   * If 'undefined' then 'convertSessionIdToMongoObjectId' must be 'true'.
+   * Default 'undefined'
+   */
+  idSessionProvider?: () => string | object;
+  /**
    * Function that generate the id for new objects.
    */
   idProvider?: () => string | object;


### PR DESCRIPTION
This fix is related to this bug report: https://github.com/accounts-js/accounts/issues/1204

The configuration option of `convertSessionIdToMongoObjectId` was not being checked when using the `idProvider` to create a new session.