### PR TITLE
fix: patch for issue in mongo driver 4.x.x

### DIFF
--- a/.changeset/fifty-pans-smash.md
+++ b/.changeset/fifty-pans-smash.md
@@ -1,0 +1,5 @@
+---
+'@accounts/mongo-password': patch
+---
+
+If users are currently using the Node Mongo Driver v4/Mongoose v6 (both are designed for use with MongoDB 5), this patch ensures no errors thrown when using these methods.

--- a/packages/database-mongo-password/src/mongo-password.ts
+++ b/packages/database-mongo-password/src/mongo-password.ts
@@ -259,7 +259,7 @@ export class MongoServicePassword implements DatabaseInterfaceServicePassword {
         },
       }
     );
-    if (ret.result.nModified === 0) {
+    if ((ret.modifiedCount && ret.modifiedCount === 0) || (ret.result && ret.result.nModified === 0)) {
       throw new Error('User not found');
     }
   }
@@ -280,7 +280,7 @@ export class MongoServicePassword implements DatabaseInterfaceServicePassword {
         },
       }
     );
-    if (ret.result.nModified === 0) {
+    if ((ret.modifiedCount && ret.modifiedCount === 0) || (ret.result && ret.result.nModified === 0)) {
       throw new Error('User not found');
     }
   }


### PR DESCRIPTION
I know some issues were addressed in #1180.  These are a couple of other issues that arise because in this version of the driver, the result of updateOne() and updateMany() is now different.  Keeping previous check in there for backwards compatibility.