### PR TITLE
feat: express endpoints for mail verification and password reset

### DIFF
--- a/.changeset/@accounts_password-1262-dependencies.md
+++ b/.changeset/@accounts_password-1262-dependencies.md
@@ -1,0 +1,5 @@
+---
+'@accounts/password': patch
+---
+dependencies updates:
+  - Added dependency [`validator@^13.11.0` ↗︎](https://www.npmjs.com/package/validator/v/13.11.0) (to `dependencies`)

--- a/examples/graphql-server-typescript/package.json
+++ b/examples/graphql-server-typescript/package.json
@@ -19,11 +19,16 @@
     "@envelop/graphql-modules": "6.0.0",
     "@graphql-tools/merge": "9.0.0",
     "@graphql-tools/schema": "10.0.0",
+    "express": "^4.18.2",
     "graphql": "16.8.1",
     "graphql-modules": "3.0.0-alpha-20231106133212-0b04b56e",
     "graphql-tag": "2.12.6",
     "graphql-yoga": "5.0.0",
+    "helmet": "^7.1.0",
     "mongoose": "7.6.4",
     "tslib": "2.6.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21"
   }
 }

--- a/packages/password/package.json
+++ b/packages/password/package.json
@@ -24,13 +24,16 @@
   "dependencies": {
     "@accounts/two-factor": "^0.32.4",
     "bcryptjs": "2.4.3",
-    "tslib": "2.6.2"
+    "tslib": "2.6.2",
+    "validator": "^13.11.0"
   },
   "devDependencies": {
     "@accounts/server": "^0.33.1",
     "@accounts/types": "^0.33.1",
     "@types/bcryptjs": "2.4.6",
+    "@types/express": "^4.17.21",
     "@types/lodash.set": "4.3.9",
+    "@types/validator": "^13",
     "graphql": "16.8.1",
     "graphql-modules": "3.0.0-alpha-20231106133212-0b04b56e",
     "lodash.set": "4.3.2",

--- a/packages/password/src/endpoints/Request.d.ts
+++ b/packages/password/src/endpoints/Request.d.ts
@@ -1,0 +1,10 @@
+declare namespace Express {
+  export interface Request {
+    userAgent: string;
+    ip: string;
+    infos: {
+      userAgent: string;
+      ip: string;
+    };
+  }
+}

--- a/packages/password/src/endpoints/express.ts
+++ b/packages/password/src/endpoints/express.ts
@@ -1,0 +1,109 @@
+import { type Injector } from 'graphql-modules';
+import type { Request, Response, NextFunction } from 'express';
+import validator from 'validator';
+import AccountsPassword from '../accounts-password';
+
+function getHtml(title: string, body: string) {
+  return `
+    <!DOCTYPE html>
+    <html lang="en">
+      <head>
+        <title>${title}</title>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+      </head>
+      <body>
+        ${body}
+      </body>
+    </html>
+  `;
+}
+
+export const infosMiddleware = (req: Request, _res: Response, next: NextFunction) => {
+  const userAgent = 'userAgent';
+  const ip = 'ip';
+  req.infos = {
+    userAgent,
+    ip,
+  };
+  next();
+};
+
+export const verifyEmail = (injector: Injector) => async (req: Request, res: Response) => {
+  try {
+    const { token } = req.params;
+    if (token == null) {
+      throw new Error('Token is missing');
+    }
+    await injector.get(AccountsPassword).verifyEmail(token);
+    res.send(
+      getHtml(
+        'Email successfully verified',
+        `
+      <h3>The email address has been successfully verified.</h3>
+    `
+      )
+    );
+  } catch (err: any) {
+    res.send(
+      //codeql[js/xss-through-exception]
+      getHtml(
+        'Email verification error',
+        `
+      <h3>The email address couldn't be verified: ${err.message ?? 'unknown error'}</h3>
+    `
+      )
+    );
+  }
+};
+
+export const resetPassword = (injector: Injector) => async (req: Request, res: Response) => {
+  try {
+    const { token, newPassword } = req.body;
+    if (token == null) {
+      throw new Error('Token is missing');
+    }
+    if (newPassword == null) {
+      throw new Error('New password is missing');
+    }
+    await injector.get(AccountsPassword).resetPassword(token, newPassword, req.infos);
+    res.send(
+      getHtml(
+        'Password successfully changed',
+        `
+      <h3>The password has been successfully changed.</h3>
+    `
+      )
+    );
+  } catch (err: any) {
+    //codeql[js/xss-through-exception]
+    res.send(
+      getHtml(
+        'Password reset error',
+        `
+      <h3>The password couldn't be changed: ${err.message ?? 'unknown error'}</h3>
+    `
+      )
+    );
+  }
+};
+
+export const resetPasswordForm = (req: Request, res: Response): Response =>
+  res.send(
+    getHtml(
+      'Reset password',
+      `
+    <div class="container">
+    <h1>Reset your password</h1>
+    <form action="/resetPassword" method="POST">
+      <input type="hidden" name="token" value=${validator.escape(req.params.token)} />
+      <div class="form-group">
+        <label for="newPassword">New password</label>
+        <input type="text" class="form-control" id="newPassword" value="" placeholder="Enter your new password" name="newPassword">
+      </div>
+      <button type="submit" class="btn btn-primary">Submit</button>
+    </form>
+  `
+    )
+  );

--- a/packages/password/src/endpoints/index.ts
+++ b/packages/password/src/endpoints/index.ts
@@ -1,0 +1,1 @@
+export * from './express';

--- a/packages/password/src/index.ts
+++ b/packages/password/src/index.ts
@@ -1,5 +1,6 @@
 import AccountsPassword, { AccountsPasswordOptions } from './accounts-password';
 export * from './types';
+export * from './endpoints';
 export {
   AddEmailErrors,
   ChangePasswordErrors,

--- a/yarn.lock
+++ b/yarn.lock
@@ -536,13 +536,16 @@ __metadata:
     "@accounts/two-factor": "npm:^0.32.4"
     "@accounts/types": "npm:^0.33.1"
     "@types/bcryptjs": "npm:2.4.6"
+    "@types/express": "npm:^4.17.21"
     "@types/lodash.set": "npm:4.3.9"
+    "@types/validator": "npm:^13"
     bcryptjs: "npm:2.4.3"
     graphql: "npm:16.8.1"
     graphql-modules: "npm:3.0.0-alpha-20231106133212-0b04b56e"
     lodash.set: "npm:4.3.2"
     reflect-metadata: "npm:0.1.13"
     tslib: "npm:2.6.2"
+    validator: "npm:^13.11.0"
   peerDependencies:
     "@accounts/server": ^0.32.0 || ^0.33.0
     graphql: ^16.0.0
@@ -4142,10 +4145,13 @@ __metadata:
     "@envelop/graphql-modules": "npm:6.0.0"
     "@graphql-tools/merge": "npm:9.0.0"
     "@graphql-tools/schema": "npm:10.0.0"
+    "@types/express": "npm:^4.17.21"
+    express: "npm:^4.18.2"
     graphql: "npm:16.8.1"
     graphql-modules: "npm:3.0.0-alpha-20231106133212-0b04b56e"
     graphql-tag: "npm:2.12.6"
     graphql-yoga: "npm:5.0.0"
+    helmet: "npm:^7.1.0"
     mongoose: "npm:7.6.4"
     tslib: "npm:2.6.2"
   languageName: unknown
@@ -7911,7 +7917,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/express@npm:*, @types/express@npm:4.17.21, @types/express@npm:^4.17.13":
+"@types/express@npm:*, @types/express@npm:4.17.21, @types/express@npm:^4.17.13, @types/express@npm:^4.17.21":
   version: 4.17.21
   resolution: "@types/express@npm:4.17.21"
   dependencies:
@@ -8504,6 +8510,13 @@ __metadata:
   version: 2.0.10
   resolution: "@types/unist@npm:2.0.10"
   checksum: 5f247dc2229944355209ad5c8e83cfe29419fa7f0a6d557421b1985a1500444719cc9efcc42c652b55aab63c931813c88033e0202c1ac684bcd4829d66e44731
+  languageName: node
+  linkType: hard
+
+"@types/validator@npm:^13":
+  version: 13.11.6
+  resolution: "@types/validator@npm:13.11.6"
+  checksum: 3201902a8e5d4784d1c67f5a5a796d1500bae10fe5413ed75fdbdf5d6b5572952445f3482ffe64908531b20171d4c5cfe94934de3fd401781bb6cf9f95766b02
   languageName: node
   linkType: hard
 
@@ -14160,7 +14173,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express@npm:4.18.2, express@npm:^4.17.1, express@npm:^4.17.3":
+"express@npm:4.18.2, express@npm:^4.17.1, express@npm:^4.17.3, express@npm:^4.18.2":
   version: 4.18.2
   resolution: "express@npm:4.18.2"
   dependencies:
@@ -15780,6 +15793,13 @@ __metadata:
     capital-case: "npm:^1.0.4"
     tslib: "npm:^2.0.3"
   checksum: c9f295d9d8e38fa50679281fd70d80726962256e888a76c8e72e526453da7a1832dcb427caa716c1ad5d79841d4537301b90156fa30298fefd3d68f4ea2181bb
+  languageName: node
+  linkType: hard
+
+"helmet@npm:^7.1.0":
+  version: 7.1.0
+  resolution: "helmet@npm:7.1.0"
+  checksum: 8c3370d07487be11ac918577c68952e05d779a1a2c037023c1ba763034c381a025899bc52f8acfab5209304a1dc618a3764dbfd26386a0d1173befe4fb932e84
   languageName: node
   linkType: hard
 
@@ -28763,6 +28783,13 @@ __metadata:
   dependencies:
     builtins: "npm:^5.0.0"
   checksum: 36a9067650f5b90c573a0d394b89ddffb08fe58a60507d7938ad7c38f25055cc5c6bf4a10fbd604abe1f4a31062cbe0dfa8e7ccad37b249da32e7b71889c079e
+  languageName: node
+  linkType: hard
+
+"validator@npm:^13.11.0":
+  version: 13.11.0
+  resolution: "validator@npm:13.11.0"
+  checksum: 0107da3add5a4ebc6391dac103c55f6d8ed055bbcc29a4c9cbf89eacfc39ba102a5618c470bdc33c6487d30847771a892134a8c791f06ef0962dd4b7a60ae0f5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
![image](https://github.com/accounts-js/accounts/assets/1047358/a5e6a874-bebe-4e0e-b8f5-907212b12e4e)

There were no endpoints to allow the user to validate the email or reset the password, so I created them.
Doing the email validation call directly from the client wasn't an option because it's not realistic to expect the user to manually type such a long token so instead he can simply click on the link in the email and he will be greeted by some static html confirming or denying the process.
Password reset on the other hand requires the user to type a new password so he will be presented with a static html form that in turn will call another REST endpoint that gets the job done. Again it is not realistic to expect the user to type such a long token, so with the client taken out of the equation the only other option would be to generate a new password from the backend instead of letting the user choose his own. This would still require a rest endpoint and it would negate the flexibility of letting the user choose his own password.
These endpoints can be used by both rest and graphql users. The graphql-yoga example shows how to create an express app which makes use of these endpoints and delegates the `/graphql` path to yoga for graphql.